### PR TITLE
docs(copilot): add copilot instructions for Astro monorepo migration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,175 @@
+# esyfo-microfrontends
+
+Astro 5 SSR monorepo that consolidates three separate microfrontends and a shared proxy backend into one application. Replaces `aktivitetskrav-mikrofrontend`, `dialogmote-mikrofrontend`, `meroppfolging-mikrofrontend`, and `esyfo-proxy`.
+
+## Team
+- **Team**: team-esyfo, NAV IT
+- **Org**: navikt
+
+## Commands
+
+```bash
+npm install                                    # Install all dependencies
+npm run dev:dialogmote-microfrontend           # Dev server for dialogmote (Astro + Hono mock)
+npm run dev:aktivitetskrav-microfrontend       # Dev server for aktivitetskrav
+npm run dev:meroppfolging-microfrontend        # Dev server for meroppfolging
+npm run build:dialogmote-microfrontend         # Build dialogmote workspace
+npm run build:aktivitetskrav-microfrontend     # Build aktivitetskrav workspace
+npm run build:meroppfolging-microfrontend      # Build meroppfolging workspace
+```
+
+Each workspace also has local scripts:
+```bash
+cd microfrontends/dialogmote
+npm run dev          # Astro dev + mock server (concurrently)
+npm run build        # astro check && astro build
+npm run mock         # Hono mock server only (port 3000)
+```
+
+> **Note**: This repo uses npm workspaces today. Migration to **pnpm** is planned. Until then, use `npm` for all commands. When migrating: delete `package-lock.json`, create `.npmrc` with `shamefully-hoist=true`, run `pnpm install`, and update CI workflows.
+
+## NAV Principles
+- **Team First**: Autonomous teams with circles of autonomy
+- **Product Development**: Continuous development over ad hoc approaches
+- **Essential Complexity**: Focus on essential, avoid accidental complexity
+- **DORA Metrics**: Measure and improve team performance
+
+## Platform & Auth
+- **Platform**: NAIS (Kubernetes on GCP)
+- **Auth**: TokenX (on-behalf-of token exchange for backend calls), ID-porten (citizen login)
+- **Observability**: OpenTelemetry auto-instrumentation via NAIS (`@opentelemetry/sdk-node`), structured logging via `pino`
+
+## Architecture
+
+### Monorepo Structure
+npm workspaces with independent Astro apps under `microfrontends/`:
+
+```
+esyfo-microfrontends/
+├── package.json                  # Root: shared dependencies + workspace scripts
+├── microfrontends/
+│   ├── dialogmote/               # Dialogmøte microfrontend (active)
+│   ├── aktivitetskrav-microfrontend/  # Aktivitetskrav microfrontend (template phase)
+│   └── meroppfolging/            # Meroppfølging microfrontend (not started)
+```
+
+Each workspace is a self-contained Astro SSR app with its own `Dockerfile`, `nais/` manifests, deploy workflow, and `astro.config.mjs`. Shared dependencies live in root `package.json`; workspace `package.json` files contain only scripts and metadata.
+
+### Astro SSR
+- **Output**: `server` mode with `@astrojs/node` adapter (standalone)
+- **Pages**: `src/pages/[locale]/index.astro` — i18n routing with `nb`, `nn`, `en`
+- **Middleware**: `src/middleware/index.ts` — validates TokenX tokens via `@navikt/oasis`
+- **Health endpoints**: `src/pages/api/internal/isAlive.ts`, `isReady.ts`
+- **Env schema**: Server secrets defined in `astro.config.mjs` via `envField` — imported from `astro:env/server`
+- **Build output**: `dist/server/entry.mjs` (SSR server) + `dist/client/_astro/` (CDN assets)
+
+### Islands Architecture
+- Server-rendered `.astro` components handle layout and data fetching
+- React components used as client islands via `client:only="react"` when interactivity is needed
+- React 18 shared via import maps from NAV CDN (`importmap.json`) — not bundled
+
+### Token Exchange (replaces esyfo-proxy)
+Each Astro workspace handles its own token exchange server-side, eliminating the need for the separate `esyfo-proxy` Express app:
+
+1. Middleware validates incoming TokenX token → stores in `Astro.locals.token`
+2. Page frontmatter calls `requestOboToken(token, clientId)` via `@navikt/oasis`
+3. OBO token used to call backend APIs directly from the server
+4. Backend URLs and client IDs configured via `astro:env/server` schema
+
+### CSS Strategy
+- `postcss-prefix-selector` scopes all CSS with a unique class per microfrontend (e.g., `.dialogmote-microfrontend`)
+- CSS Modules (`.module.css`) for component-level scoping — excluded from prefix selector
+- Aksel CSS imported as `@src/styles/aksel.css`
+- `inlineStylesheets: "always"` in Astro build config
+
+### Deploy
+Per-workspace GitHub Actions workflow with path-based triggers:
+1. `npm ci` + `npm run build:<workspace>`
+2. CDN upload: `dist/client/_astro/` → `cdn.nav.no/min-side/<app-name>`
+3. Docker build from workspace Dockerfile (distroless Node image)
+4. Register in `tms-deploy` microfrontend manifest (SSR variant)
+5. NAIS deploy to `dev-gcp` / `prod-gcp`
+
+## Tech Stack
+- **Framework**: Astro 5 (`astro`, `@astrojs/node`, `@astrojs/react`)
+- **UI**: React 18, `@navikt/ds-react` (Aksel 6), `@navikt/aksel-icons`
+- **Auth**: `@navikt/oasis` (TokenX validation + OBO token exchange)
+- **Validation**: Zod (API response schemas in `schema/` directory)
+- **Logging**: `pino` with structured JSON output
+- **Observability**: `@opentelemetry/sdk-node` (auto-instrumented by NAIS)
+- **Analytics**: `@navikt/nav-dekoratoren-moduler` (`getAnalyticsInstance`)
+- **Lint/Format**: Biome (`@biomejs/biome`)
+- **Mock server**: Hono + `@hono/node-server` (development)
+- **Build tooling**: `rollup-plugin-import-map` (React from CDN), `postcss-prefix-selector`
+- **Container**: `gcr.io/distroless/nodejs22-debian12` / `nodejs24-debian12`
+
+## Conventions
+- English code and comments — Norwegian for user-facing text and domain terms (e.g. dialogmøte, sykmelding, aktivitetskrav, motebehov)
+- **Documentation lookup strategy** (prioritert rekkefølge):
+  1. **Repo first**: Check existing code and custom instructions (`.github/instructions/`)
+  2. **NAV-docs when needed**: Look up aksel.nav.no (UI components, design tokens) and doc.nais.io (platform, deploy, observability) when creating or changing something in these domains
+  3. **External docs when uncertain**: Use web search for external libraries only when unsure about API correctness — not routinely
+- Check existing code patterns in the repository before writing new code
+- Follow the ✅ Always / ⚠️ Ask First / 🚫 Never boundaries in instruction files
+- Biome for all formatting and linting (not ESLint/Prettier)
+- Path aliases: `@src/*` → `src/*`, `@schema/*` → `schema/*` (in tsconfig.json)
+
+## Migration Status
+
+See `.github/instructions/migration.instructions.md` for full details.
+
+| Workspace | Status | Notes |
+|-----------|--------|-------|
+| dialogmote | ✅ Active development | Domain logic migrated, Astro components working |
+| aktivitetskrav | 🔄 Template phase | Workspace exists but contains template artifacts to clean up |
+| meroppfolging | ⏳ Not started | Referenced in scripts but directory doesn't exist yet |
+
+## Boundaries
+
+### ✅ Always
+- Fetch data server-side in Astro frontmatter — never client-side against NAV backends
+- Validate tokens in middleware via `@navikt/oasis`
+- Use Aksel components from `@navikt/ds-react`
+- Use Zod for API response validation (schemas in `schema/` directory)
+- Keep CSS prefix unique per microfrontend
+- Run `npm run build` in the workspace to verify changes
+- Use `astro:env/server` for server secrets — never expose to client
+
+### ⚠️ Ask First
+- Adding new npm dependencies (affects all workspaces via root `package.json`)
+- Changing token exchange or auth flow
+- Changing deploy workflow or NAIS manifest
+- Sharing code between workspaces (consider if patterns should be duplicated or shared)
+- Changing the import map configuration
+
+### 🚫 Never
+- Client-side data fetching against NAV backends (all data is fetched server-side)
+- Skip TokenX validation in middleware
+- Log tokens, PII, or fødselsnummer
+- Import between workspaces without explicit sharing mechanism
+- Bundle React (it's shared via import map from CDN)
+- Use `getStaticPaths` (this is SSR, not SSG)
+
+## Documentation and Working Notes
+
+| Tier | Location | Purpose | Persists | Checked in |
+|------|----------|---------|----------|------------|
+| **Session** | `~/.copilot/session-state/` | Scratch work for one task | No | No |
+| **Local notes** | `.local-notes/` | Plans, architecture drafts, research, AI reviews | Yes | No |
+| **Permanent docs** | `docs/` | Finalized documentation (ADRs, API docs) | Yes | Yes |
+
+**Defaults**: Planning/research/drafts → `.local-notes/`. Finalized docs → `docs/`. Task tracking → session state.
+
+## Keeping Copilot Config in Sync
+
+When making changes that affect patterns described in `.github/` config files (instructions, prompts, skills), **suggest** updating — but do not update automatically.
+
+Examples: upgrading frameworks, changing test patterns, adding auth mechanisms, changing build tooling.
+
+**Check the file header first** to determine where changes belong:
+
+- **Managed files** (header: `<!-- Managed by esyfo-cli …-->`) — Do NOT edit locally. Changes will be overwritten by the next sync.
+  Format: *"This change affects patterns in `.github/instructions/<file>`, which is managed by esyfo-cli. The source should be updated in the esyfo-cli repo under `copilot-config/`."*
+
+- **Locally owned files** (no managed header) — Suggest updating the file directly in this repo.
+  Format: *"This change affects patterns in `.github/instructions/<file>` — want me to update it?"*

--- a/.github/instructions/astro.instructions.md
+++ b/.github/instructions/astro.instructions.md
@@ -1,0 +1,189 @@
+---
+applyTo: "**/*.astro,**/astro.config.mjs,**/middleware/**/*.ts,**/pages/**/*.ts,**/pages/**/*.astro"
+---
+
+# Astro SSR Patterns
+
+## Component Structure (.astro files)
+
+Astro components have two sections separated by `---` fences:
+
+```astro
+---
+// Frontmatter: server-side TypeScript
+// - Imports
+// - Token exchange + data fetching
+// - Business logic
+import { fetchBrev } from "@src/utils/fetch";
+import type { BrevDTO } from "@schema/brevSchema";
+
+const userToken = Astro.locals.token;
+const brev: BrevDTO[] = await fetchBrev(userToken);
+---
+
+<!-- Template: HTML + Astro components + React islands -->
+<div class="dialogmote-microfrontend">
+  <MyComponent data={brev} />
+</div>
+```
+
+- **Frontmatter** runs on the server — safe to use tokens, call backends, access secrets
+- **Template** renders to HTML — use Astro components for static content, React islands for interactivity
+
+## Server-Side Data Fetching
+
+All backend data is fetched in frontmatter using OBO tokens:
+
+```astro
+---
+import { requestOboToken } from "@navikt/oasis";
+import { BACKEND_API_URL, BACKEND_CLIENT_ID } from "astro:env/server";
+
+const userToken = Astro.locals.token;
+const oboResult = await requestOboToken(userToken, BACKEND_CLIENT_ID);
+
+if (!oboResult.ok) {
+  return new Response("Token exchange failed", { status: 503 });
+}
+
+const response = await fetch(`${BACKEND_API_URL}/api/endpoint`, {
+  headers: { Authorization: `Bearer ${oboResult.token}` },
+});
+const data = await response.json();
+---
+```
+
+**Pattern**: Token comes from `Astro.locals.token` (set by middleware) → exchange via `requestOboToken` → call backend with OBO token.
+
+## Islands (Client-Side React)
+
+Use `client:only="react"` for interactive components:
+
+```astro
+---
+import MyReactComponent from "@src/components/MyComponent.tsx";
+---
+<MyReactComponent client:only="react" someProp={data} />
+```
+
+- **Minimize client islands** — server-render everything that doesn't need interactivity
+- React is NOT bundled — it's loaded via import map from NAV CDN (`importmap.json`)
+- Only pass serializable props to client components
+
+## Env Schema (astro:env/server)
+
+Server secrets are defined in `astro.config.mjs`:
+
+```javascript
+env: {
+  schema: {
+    BACKEND_API_URL: envField.string({
+      context: "server",
+      access: "secret",
+      default: "http://localhost:3000/api/backend",
+    }),
+    BACKEND_CLIENT_ID: envField.string({
+      context: "server",
+      access: "secret",
+      default: "dev-gcp:team-name:app-name",
+    }),
+  },
+},
+```
+
+Import in code: `import { BACKEND_API_URL } from "astro:env/server";`
+
+## Middleware
+
+Token validation in `src/middleware/index.ts`:
+
+```typescript
+import { getToken, validateTokenxToken } from "@navikt/oasis";
+import { defineMiddleware } from "astro/middleware";
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const token = getToken(context.request.headers);
+
+  if (isLocal) return next();           // Skip in development
+  if (isInternal(context)) return next(); // Skip for health endpoints
+
+  if (!token) return new Response(null, { status: 401 });
+
+  const validation = await validateTokenxToken(token);
+  if (!validation.ok) return new Response(null, { status: 401 });
+
+  context.locals.token = token;
+  return next();
+});
+```
+
+## Pages & Routing
+
+```
+src/pages/
+├── index.astro                    # Redirect to default locale
+├── [locale]/
+│   ├── index.astro                # Main page (data fetching + rendering)
+│   └── fallback.astro             # Error/fallback state
+└── api/
+    └── internal/
+        ├── isAlive.ts             # Liveness probe
+        └── isReady.ts             # Readiness probe
+```
+
+- i18n configured in `astro.config.mjs` with `prefixDefaultLocale: true`
+- Locales: `nb` (default), `nn`, `en`
+
+## CSS in Astro
+
+### Prefix Selector
+Each microfrontend has a unique CSS prefix configured in `astro.config.mjs`:
+
+```javascript
+prefixer({
+  prefix: ".dialogmote-microfrontend",
+  ignoreFiles: [/module.css/],  // CSS modules are NOT prefixed
+})
+```
+
+### CSS Modules
+Use `.module.css` for component-scoped styles:
+```astro
+---
+import styles from "@src/styles/index.module.css";
+---
+<div class={styles.wrapper}>...</div>
+```
+
+### Aksel CSS
+Import once in the main page: `import "@src/styles/aksel.css";`
+
+## Error Handling
+
+Return `Response` objects from frontmatter for error states:
+
+```astro
+---
+try {
+  const data = await fetchData(token);
+} catch (error) {
+  logger.error(`Error: ${error}`);
+  return new Response("Internal Server Error", { status: 503 });
+}
+---
+```
+
+## Boundaries
+
+### ✅ Always
+- Fetch data server-side in frontmatter
+- Use `astro:env/server` for secrets
+- Wrap backend calls in try/catch with logging
+- Return appropriate HTTP status codes on error
+- Keep the CSS prefix class on the root wrapper element
+
+### 🚫 Never
+- Use `getStaticPaths` (this is SSR, not SSG)
+- Expose server secrets via client-accessible env vars
+- Fetch data client-side against NAV backends
+- Import heavy libraries into client islands (React is via import map)

--- a/.github/instructions/migration.instructions.md
+++ b/.github/instructions/migration.instructions.md
@@ -1,0 +1,125 @@
+---
+applyTo: "**/*"
+---
+
+# Migration Context
+
+## What's Being Migrated
+
+Three separate Vite/React microfrontends + one Express proxy backend → one Astro SSR monorepo.
+
+| Old Repo | Type | Status | New Workspace |
+|----------|------|--------|---------------|
+| `aktivitetskrav-mikrofrontend` | Vite/React SPA | 🔄 Template phase | `microfrontends/aktivitetskrav-microfrontend` |
+| `dialogmote-mikrofrontend` | Vite/React SPA | ✅ Active development | `microfrontends/dialogmote` |
+| `meroppfolging-mikrofrontend` | Vite/React SPA | ⏳ Not started | `microfrontends/meroppfolging` |
+| `esyfo-proxy` | Express.js backend | ✅ Replaced by Astro middleware | Built into each workspace |
+
+## Architecture Changes
+
+### Before (old architecture)
+```
+Browser → Client-side React SPA (Vite bundle)
+            ↓ SWR fetch
+         esyfo-proxy (Express)
+            ↓ TokenX exchange (manual, with node-cache)
+         Backend APIs (isdialogmote, syfomotebehov, etc.)
+```
+
+- React SPAs hosted as microfrontends in tms-min-side
+- Data fetched client-side via SWR → esyfo-proxy
+- esyfo-proxy: shared Express server handling TokenX exchange for all microfrontends
+- Manual TokenX implementation using `openid-client`, `node-jose`, `jsonwebtoken`
+- In-memory token caching via `node-cache`
+
+### After (new architecture)
+```
+Browser → Astro SSR app (server-rendered HTML)
+            ↓ Server-side fetch in frontmatter
+         @navikt/oasis (requestOboToken)
+            ↓ TokenX OBO exchange
+         Backend APIs (isdialogmote, syfomotebehov, etc.)
+```
+
+- Astro SSR apps render data server-side — no client-side API calls
+- Token exchange via `@navikt/oasis` (standard NAV library) — no custom implementation
+- Each workspace handles its own token exchange independently
+- No shared proxy — each workspace calls its backends directly
+
+## esyfo-proxy Endpoints Being Replaced
+
+Reference for which backend calls each workspace needs:
+
+| Proxy Route | Backend Host | Backend Path | Client ID | Workspace |
+|-------------|-------------|--------------|-----------|-----------|
+| `GET /api/dialogmote` | `ISDIALOGMOTE_HOST` | `/api/v2/arbeidstaker/brev` | `ISDIALOGMOTE_CLIENT_ID` | dialogmote |
+| `GET /api/motebehov` | `SYFOMOTEBEHOV_HOST` | `/syfomotebehov/api/v4/arbeidstaker/motebehov` | `SYFOMOTEBEHOV_CLIENT_ID` | dialogmote |
+| `GET /api/aktivitetsplikt` | `AKTIVITETSKRAV_BACKEND_HOST` | (check esyfo-proxy routes) | `AKTIVITETSKRAV_BACKEND_CLIENT_ID` | aktivitetskrav |
+| `GET /api/meroppfolging/v2/senoppfolging/status` | `MEROPPFOLGING_BACKEND_HOST` | `/api/v2/senoppfolging/status` | `MEROPPFOLGING_BACKEND_CLIENT_ID` | meroppfolging |
+| `GET /api/mikrofrontend/v1/status` | `MEROPPFOLGING_BACKEND_HOST` | `/api/mikrofrontend/v1/status` | `MEROPPFOLGING_BACKEND_CLIENT_ID` | meroppfolging |
+
+## Known Template Artifacts to Clean Up (aktivitetskrav workspace)
+
+The aktivitetskrav workspace was scaffolded from `tms-microfrontend-template-ssr` and still contains template references:
+
+- `package.json` name: `"tms-microfrontend-template-ssr"` → should be `"aktivitetskrav-microfrontend"`
+- `astro.config.mjs` assetsPrefix: `"tms-microfrontend-template-ssr"` → update to `"aktivitetskrav-microfrontend"`
+- `astro.config.mjs` CSS prefix: `".tms-microfrontend-template-ssr"` → update to `".aktivitetskrav-microfrontend"`
+- `astro.config.mjs` env schema: `EXAMPLE_API_URL` → replace with actual backend env vars
+- Placeholder data types and fetch logic → replace with aktivitetskrav domain types
+- `nais/` manifests: verify namespace, team labels, access policies
+- `src/styles/index.module.css`: contains debug border styling → remove
+
+## Workspace Name Mismatch
+
+⚠️ Root `package.json` workspaces reference `"microfrontends/aktivitetskrav"` but the actual directory is `microfrontends/aktivitetskrav-microfrontend`. This should be harmonized — either rename the directory or update the workspace path.
+
+## Technology Migration Map
+
+### Patterns NOT to carry forward from old repos
+
+| Old Pattern | Replacement | Notes |
+|-------------|-------------|-------|
+| `styled-components` | CSS Modules + Aksel tokens | No runtime CSS-in-JS |
+| `SWR` / client-side fetch | Server-side fetch in Astro frontmatter | Data fetched on server, not browser |
+| `react-error-boundary` | Astro error handling (`return new Response(...)`) | Server-side error responses |
+| `MSW` (Mock Service Worker) | Hono mock server (`mock/server.ts`) | Server-side mocks, not browser |
+| `@grafana/faro-web-sdk` | OpenTelemetry auto-instrumentation (NAIS) | Platform-level observability |
+| `ESLint` + `Prettier` | Biome | Single tool for lint + format |
+| `Vite` config | Astro config (`astro.config.mjs`) | Vite is used internally by Astro |
+| Manual TokenX (`openid-client`, `node-jose`) | `@navikt/oasis` (`requestOboToken`) | Standard NAV auth library |
+| `node-cache` (token caching) | Not needed | `@navikt/oasis` handles caching |
+| `dayjs` | Native date formatting or `@src/utils/dateUtils.ts` | Minimize dependencies |
+| `@navikt/nav-dekoratoren-moduler` v2 | `@navikt/nav-dekoratoren-moduler` v3 | Updated analytics API |
+| Aksel v5/v7 (mixed across repos) | Aksel v6 (consistent) | Standardized in monorepo |
+
+## Migration Checklist per Workspace
+
+When migrating a microfrontend, follow this pattern (using dialogmote as reference):
+
+1. **Create workspace directory** under `microfrontends/`
+2. **Set up Astro config** — copy from dialogmote, update CSS prefix, env schema, and assetsPrefix
+3. **Create middleware** — copy from dialogmote (identical for all workspaces)
+4. **Define Zod schemas** in `schema/` — port from old repo's schema files
+5. **Create fetch utilities** in `src/utils/fetch.ts` — server-side with OBO token
+6. **Build Astro components** — convert React components to `.astro` where possible
+7. **Add React islands** only for interactive elements (`client:only="react"`)
+8. **Set up mock server** in `mock/` — Hono endpoints matching the real API
+9. **Create NAIS manifests** in `nais/` — dev-gcp and prod-gcp
+10. **Create deploy workflow** in `.github/workflows/`
+11. **Add root scripts** in root `package.json` (dev/build for the new workspace)
+12. **Verify import map** — ensure `importmap.json` is present
+
+## Planned: npm → pnpm
+
+The monorepo uses npm workspaces today. Migration to pnpm is planned.
+
+When migrating:
+1. Delete `package-lock.json`
+2. Create/update `.npmrc` for pnpm compatibility
+3. Run `pnpm install` to generate `pnpm-lock.yaml`
+4. Update root `package.json` scripts (`npm run` → `pnpm run`, `--workspace=` → `--filter`)
+5. Update all GitHub Actions workflows (`npm ci` → `pnpm install --frozen-lockfile`, cache strategy)
+6. Update Dockerfiles if they reference `npm`
+
+Until then: use `npm` for all commands.


### PR DESCRIPTION
Legger til lokalt eide copilot-instruksjoner for esyfo-microfrontends monorepoet.

### Nye filer

- **`.github/copilot-instructions.md`** — Hovedinstruksjoner med arkitektur, tech stack, konvensjoner og boundaries
- **`.github/instructions/astro.instructions.md`** — Astro SSR-spesifikke patterns (frontmatter data fetching, islands, middleware, CSS)
- **`.github/instructions/migration.instructions.md`** — Migrasjonskontekst: hva som erstattes, proxy-endepunkter, cleanup-liste, teknologi-migrasjonskart

### Kontekst

Disse filene gir Copilot rik kontekst for å hjelpe med migrasjonen av aktivitetskrav-mikrofrontend, dialogmote-mikrofrontend, meroppfolging-mikrofrontend og esyfo-proxy inn i dette monorepoet.

Filene er **lokalt eid** (ikke managed av esyfo-cli sync). Managed filer (auth, security, nais instructions etc.) vil bli pushet via en separat `copilot sync`-kjøring etter at [esyfo-cli PR] merges.