### PR TITLE
chore(deps): bump Aksel to v8

### DIFF
--- a/microfrontends/aktivitetskrav/src/components/common/MikrofrontendLinkPanel.module.css
+++ b/microfrontends/aktivitetskrav/src/components/common/MikrofrontendLinkPanel.module.css
@@ -6,10 +6,10 @@
   align-items: center;
   justify-content: space-between;
   border-bottom: 1px solid #0000001a;
-  padding: var(--a-spacing-4) var(--a-spacing-4) var(--a-spacing-3);
+  padding: var(--ax-space-16) var(--ax-space-16) var(--ax-space-12);
 
   @media (min-width: 648px) {
-    padding: var(--a-spacing-5) var(--a-spacing-5) var(--a-spacing-4);
+    padding: var(--ax-space-20) var(--ax-space-20) var(--ax-space-16);
   }
 }
 
@@ -23,15 +23,15 @@
   flex-direction: row;
   width: 100%;
   align-items: center;
-  padding: var(--a-spacing-3) var(--a-spacing-4) var(--a-spacing-4);
+  padding: var(--ax-space-12) var(--ax-space-16) var(--ax-space-16);
 
   @media (min-width: 648px) {
-    padding: var(--a-spacing-4) var(--a-spacing-5) var(--a-spacing-5);
+    padding: var(--ax-space-16) var(--ax-space-20) var(--ax-space-20);
   }
 }
 
 .mainContentText {
-  font-weight: var(--a-font-weight-regular);
+  font-weight: var(--ax-font-weight-regular);
 }
 
 .chevronPanel {
@@ -49,7 +49,7 @@
 }
 
 .chevronPanel:hover {
-  box-shadow: var(--a-shadow-small);
+  box-shadow: var(--ax-shadow-dialog);
 }
 
 .chevronPanel:hover .headingTitle {
@@ -90,11 +90,11 @@
   height: 24px;
   background: radial-gradient(
     circle at 50% 57%,
-    var(--a-surface-default) 32%,
+    var(--ax-bg-default) 32%,
     0,
     transparent
   );
-  color: var(--ac-alert-icon-warning-color, var(--a-icon-warning));
+  color: var(--ax-text-warning-decoration);
 }
 
 .sucessIcon {
@@ -104,11 +104,11 @@
   height: 24px;
   background: radial-gradient(
     circle at 50% 57%,
-    var(--a-surface-default) 32%,
+    var(--ax-bg-default) 32%,
     0,
     transparent
   );
-  color: var(--ac-alert-icon-success-color, var(--a-icon-success));
+  color: var(--ax-text-success-decoration);
 }
 
 .errorIcon {
@@ -118,11 +118,11 @@
   height: 24px;
   background: radial-gradient(
     circle at 50% 57%,
-    var(--a-surface-default) 32%,
+    var(--ax-bg-default) 32%,
     0,
     transparent
   );
-  color: var(--ac-alert-icon-error-color, var(--a-icon-danger));
+  color: var(--ax-text-danger-decoration);
 }
 
 .infoIcon {
@@ -132,9 +132,9 @@
   height: 24px;
   background: radial-gradient(
     circle at 50% 57%,
-    var(--a-surface-default) 32%,
+    var(--ax-bg-default) 32%,
     0,
     transparent
   );
-  color: var(--ac-alert-icon-info-color, var(--a-icon-info));
+  color: var(--ax-text-info-decoration);
 }

--- a/microfrontends/dialogmote/src/components/shared/Content.astro
+++ b/microfrontends/dialogmote/src/components/shared/Content.astro
@@ -44,7 +44,7 @@ export interface Props {
     </div>
     <div class={styles.mainContentRow}>
       <div class={styles.column}>
-        <Heading className={styles.maintContentText} size={Astro.props.mainContent.textFormat === "text" ? "medium" : "large"} level="3">
+        <Heading className={styles.mainContentText} size={Astro.props.mainContent.textFormat === "text" ? "medium" : "large"} level="3">
           {Astro.props.mainContent.text}
         </Heading>
           <Tag className={styles.containedTag} size="small" variant={Astro.props.mainContent.tag.variant}>

--- a/microfrontends/dialogmote/src/components/shared/Content.module.css
+++ b/microfrontends/dialogmote/src/components/shared/Content.module.css
@@ -13,7 +13,7 @@
 }
 
 .container:hover {
-  box-shadow: var(--a-shadow-small);
+  box-shadow: var(--ax-shadow-dialog);
 }
 
 .container:hover .headingTitle {
@@ -26,7 +26,7 @@
 }
 
 .link {
-  color: var(--a-text-default);
+  color: var(--ax-text-neutral);
   text-decoration: none;
 }
 
@@ -38,10 +38,10 @@
   align-items: center;
   justify-content: space-between;
   border-bottom: 1px solid #0000001a;
-  padding: var(--a-spacing-4) var(--a-spacing-4) var(--a-spacing-3);
+  padding: var(--ax-space-16) var(--ax-space-16) var(--ax-space-12);
 
   @media (min-width: 648px) {
-    padding: var(--a-spacing-5) var(--a-spacing-5) var(--a-spacing-4);
+    padding: var(--ax-space-20) var(--ax-space-20) var(--ax-space-16);
   }
 }
 
@@ -60,10 +60,10 @@
   flex-direction: row;
   width: 100%;
   align-items: center;
-  padding: var(--a-spacing-3) var(--a-spacing-4) var(--a-spacing-4);
+  padding: var(--ax-space-12) var(--ax-space-16) var(--ax-space-16);
 
   @media (min-width: 648px) {
-    padding: var(--a-spacing-4) var(--a-spacing-5) var(--a-spacing-5);
+    padding: var(--ax-space-16) var(--ax-space-20) var(--ax-space-20);
   }
 }
 
@@ -73,8 +73,8 @@
   gap: 1rem;
 }
 
-.maintContentText {
-  font-weight: var(--a-font-weight-regular);
+.mainContentText {
+  font-weight: var(--ax-font-weight-regular);
 }
 
 .containedTag {
@@ -95,9 +95,9 @@
   height: 24px;
   background: radial-gradient(
     circle at 50% 57%,
-    var(--a-surface-default) 32%,
+    var(--ax-bg-default) 32%,
     0,
     transparent
   );
-  color: var(--ac-alert-icon-warning-color, var(--a-icon-warning));
+  color: var(--ax-text-warning-decoration);
 }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "dependencies": {
     "@astrojs/node": "10.0.2",
     "@astrojs/react": "5.0.0",
-    "@navikt/aksel-icons": "6.1.1",
-    "@navikt/ds-css": "6.16.2",
-    "@navikt/ds-react": "6.16.2",
+    "@navikt/aksel-icons": "8.7.0",
+    "@navikt/ds-css": "8.7.0",
+    "@navikt/ds-react": "8.7.0",
     "@navikt/nav-dekoratoren-moduler": "3.6.3",
     "@navikt/oasis": "4.1.4",
     "@opentelemetry/sdk-node": "0.213.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
         specifier: 5.0.0
         version: 5.0.0(@types/node@25.5.0)(@types/react-dom@18.2.21)(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(tsx@4.21.0)(yaml@2.8.2)
       '@navikt/aksel-icons':
-        specifier: 6.1.1
-        version: 6.1.1
+        specifier: 8.7.0
+        version: 8.7.0
       '@navikt/ds-css':
-        specifier: 6.16.2
-        version: 6.16.2
+        specifier: 8.7.0
+        version: 8.7.0
       '@navikt/ds-react':
-        specifier: 6.16.2
-        version: 6.16.2(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 8.7.0
+        version: 8.7.0(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@navikt/nav-dekoratoren-moduler':
         specifier: 3.6.3
         version: 3.6.3(csp-header@6.3.1)(html-react-parser@5.2.17(@types/react@18.2.64)(react@18.2.0))(jsdom@29.0.0)(react@18.2.0)
@@ -353,6 +353,9 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
+  '@date-fns/tz@1.2.0':
+    resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
+
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
 
@@ -554,14 +557,11 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/react@0.25.4':
-    resolution: {integrity: sha512-lWRQ/UiTvSIBxohn0/2HFHEmnmOVRjl7j6XcRJuLH0ls6f/9AyHMWVzkAJFuwx0n9gaEeCmg9VccCSCJzbEJig==}
+  '@floating-ui/react@0.27.8':
+    resolution: {integrity: sha512-EQJ4Th328y2wyHR3KzOUOoTW2UKjFk53fmyahfwExnFQ8vnsMYqKc+fFPOkeYtj5tcp1DUMiNJ7BFhed7e9ONw==}
     peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
-  '@floating-ui/utils@0.1.6':
-    resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
@@ -753,26 +753,21 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@navikt/aksel-icons@6.1.1':
-    resolution: {integrity: sha512-gWPr+AH/N/Jcty4FGY7OnMv8hgGyf8KS0q8y1mbAyIeRY9GhuTVuFA153Pvpyyafp6t9FyilsJUkcMkrJvFySA==, tarball: https://npm.pkg.github.com/download/@navikt/aksel-icons/6.1.1/0ae4f2c1220ccec1018dcadc0ecb798fb30726c8}
+  '@navikt/aksel-icons@8.7.0':
+    resolution: {integrity: sha512-pANfaE/xr2a9Q3CYMWbCjhAk9+UNuUa50Ez37Zk2nZQYtjP1vLXluOgHrxGAGTs6T4ToE+IjtJdU9DoEBnBbdw==, tarball: https://npm.pkg.github.com/download/@navikt/aksel-icons/8.7.0/71371b0ac52d8760340b655f20580faeb47a2fb5}
 
-  '@navikt/aksel-icons@6.17.0':
-    resolution: {integrity: sha512-n+1AsE9kRFh3C7BcD0fAJhIA6/65PsLGrpNKnLQUjW8hwESzo1LYHfZgZXi2Shaw2hCzQ1wx/hBBdwtQfUiBNg==, tarball: https://npm.pkg.github.com/download/@navikt/aksel-icons/6.17.0/92f12f06c26db3c2221908da599a113654942044}
+  '@navikt/ds-css@8.7.0':
+    resolution: {integrity: sha512-kYeaCPcaNEvXixA7upGOpi3hWCvT1fZcL1arRJHSOZJf5uXm5b3Wey+WL9+5zLE7M90q6jsV/vGy4E370ZoWmg==, tarball: https://npm.pkg.github.com/download/@navikt/ds-css/8.7.0/353215289ac1a756ed37dc54379b7a501fc84a28}
 
-  '@navikt/ds-css@6.16.2':
-    resolution: {integrity: sha512-fWJRierHeHKe718crx8+TmRsKfQ+BODm13oodvt3LIiQmINNNdF7rtAFSO6+yzF6ReVj2bAnqyr+6UqDH9RJyw==, tarball: https://npm.pkg.github.com/download/@navikt/ds-css/6.16.2/6504d11c7905723a585a2c9ba2555fb5a8a159e1}
-
-  '@navikt/ds-react@6.16.2':
-    resolution: {integrity: sha512-snJnxUXiDN8wmjb3uoELhTfpdsdpftXuZBaZeLsST/skMPJHdym9D8pVjbti4pKrnG2/9zYI2rX/bE2e26D7CQ==, tarball: https://npm.pkg.github.com/download/@navikt/ds-react/6.16.2/b16cba0f95df6b9e4035099c0dc5b239dcbd5392}
+  '@navikt/ds-react@8.7.0':
+    resolution: {integrity: sha512-hb0Ah4By9H+9RH88UUudQ6onKK59V8Qe9JnHwk7RSWHJrgLhTa4wm3uSf0o08oqxp08/AiAYS5YPl0NUPf83gA==, tarball: https://npm.pkg.github.com/download/@navikt/ds-react/8.7.0/6961196212e6e8eca21fba86926327a5ad8ab074}
     peerDependencies:
-      '@types/react': ^17.0.30 || ^18.0.0
-      react: ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
+      '@types/react': ^17.0.30 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
 
-  '@navikt/ds-tokens@6.17.0':
-    resolution: {integrity: sha512-DAibs9kIcpAf/4sRTdB0VPDK6t4seeJfqTm6qvDSUkOt/UCmvgKRUeikJqETCiGgXWv/Y/FpQ69uv1stZXBrEQ==, tarball: https://npm.pkg.github.com/download/@navikt/ds-tokens/6.17.0/e80eeb7c7d6f469d6704125b5835ea95995be327}
+  '@navikt/ds-tokens@8.7.0':
+    resolution: {integrity: sha512-YEeAzjJNFXwTrx2R9xf4Sue/sTCLaygFlJ0MVgje8Q5KzLiQSaVoK6gIGZHZ4wHVU6Q1uOAlIkdaHKlPvCfu7A==, tarball: https://npm.pkg.github.com/download/@navikt/ds-tokens/8.7.0/17a22dcaa2107ac81431db172701e0debe4e3fe3}
 
   '@navikt/nav-dekoratoren-moduler@3.6.3':
     resolution: {integrity: sha512-NDPgv2G0qlrfwurHAjeXo+0hXKCpWn0RxyCgRYmxLPeDJKEL0GC3EAMsvAKM+0eGQmeOkZFUb9DOoNowcCCDgg==, tarball: https://npm.pkg.github.com/download/@navikt/nav-dekoratoren-moduler/3.6.3/fe2fc4979ca3fbd5e38c2f25d985ae58e867a23f}
@@ -1448,8 +1443,11 @@ packages:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
-  date-fns@3.6.0:
-    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+  date-fns-jalali@4.1.0-0:
+    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2161,11 +2159,11 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
-  react-day-picker@8.10.0:
-    resolution: {integrity: sha512-mz+qeyrOM7++1NCb1ARXmkjMkzWVh2GL9YiPbRjKe0zHccvekk4HE+0MPOZOrosn8r8zTHIIeOUXTmXRqmkRmg==}
+  react-day-picker@9.7.0:
+    resolution: {integrity: sha512-urlK4C9XJZVpQ81tmVgd2O7lZ0VQldZeHzNejbwLWZSkzHH498KnArT0EHNfKBOWwKc935iMLGZdxXPRISzUxQ==}
+    engines: {node: '>=18'}
     peerDependencies:
-      date-fns: ^2.28.0 || ^3.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: '>=16.8.0'
 
   react-dom@18.2.0:
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
@@ -3140,6 +3138,8 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@date-fns/tz@1.2.0': {}
+
   '@emmetio/abbreviation@2.3.3':
     dependencies:
       '@emmetio/scanner': 1.0.4
@@ -3263,15 +3263,13 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@floating-ui/react@0.25.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@floating-ui/react@0.27.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@floating-ui/utils': 0.1.6
+      '@floating-ui/utils': 0.2.11
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tabbable: 6.4.0
-
-  '@floating-ui/utils@0.1.6': {}
 
   '@floating-ui/utils@0.2.11': {}
 
@@ -3409,28 +3407,23 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@navikt/aksel-icons@6.1.1': {}
+  '@navikt/aksel-icons@8.7.0': {}
 
-  '@navikt/aksel-icons@6.17.0': {}
+  '@navikt/ds-css@8.7.0': {}
 
-  '@navikt/ds-css@6.16.2': {}
-
-  '@navikt/ds-react@6.16.2(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@navikt/ds-react@8.7.0(@types/react@18.2.64)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@floating-ui/react': 0.25.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/react': 0.27.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@floating-ui/react-dom': 2.1.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@navikt/aksel-icons': 6.17.0
-      '@navikt/ds-tokens': 6.17.0
-      clsx: 2.1.1
-      date-fns: 3.6.0
-      react: 18.2.0
-      react-day-picker: 8.10.0(date-fns@3.6.0)(react@18.2.0)
-    optionalDependencies:
+      '@navikt/aksel-icons': 8.7.0
+      '@navikt/ds-tokens': 8.7.0
       '@types/react': 18.2.64
-    transitivePeerDependencies:
-      - react-dom
+      date-fns: 4.1.0
+      react: 18.2.0
+      react-day-picker: 9.7.0(react@18.2.0)
+      react-dom: 18.2.0(react@18.2.0)
 
-  '@navikt/ds-tokens@6.17.0': {}
+  '@navikt/ds-tokens@8.7.0': {}
 
   '@navikt/nav-dekoratoren-moduler@3.6.3(csp-header@6.3.1)(html-react-parser@5.2.17(@types/react@18.2.64)(react@18.2.0))(jsdom@29.0.0)(react@18.2.0)':
     dependencies:
@@ -4217,7 +4210,9 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  date-fns@3.6.0: {}
+  date-fns-jalali@4.1.0-0: {}
+
+  date-fns@4.1.0: {}
 
   debug@4.4.3:
     dependencies:
@@ -5139,9 +5134,11 @@ snapshots:
 
   range-parser@1.2.1: {}
 
-  react-day-picker@8.10.0(date-fns@3.6.0)(react@18.2.0):
+  react-day-picker@9.7.0(react@18.2.0):
     dependencies:
-      date-fns: 3.6.0
+      '@date-fns/tz': 1.2.0
+      date-fns: 4.1.0
+      date-fns-jalali: 4.1.0-0
       react: 18.2.0
 
   react-dom@18.2.0(react@18.2.0):


### PR DESCRIPTION
## Beskrivelse

Bumper Aksel design system fra v6.16.2 til v8.7.0.

## Endringer

- `@navikt/aksel-icons` 6.1.1 → 8.7.0
- `@navikt/ds-css` 6.16.2 → 8.7.0
- `@navikt/ds-react` 6.16.2 → 8.7.0
- Migrert 23 CSS-tokenreferanser fra `--a-*` til `--ax-*` (via Aksel codemod `v8-tokens`)
- CSS-importstier i `aksel.css` uendret (fortsatt gyldige i v8)

### Filer endret
- `package.json` — bumpet Aksel-pakker
- `microfrontends/aktivitetskrav/src/components/common/MikrofrontendLinkPanel.module.css` — token-migrering
- `microfrontends/dialogmote/src/components/shared/Content.module.css` — token-migrering

## Issue

Closes #51

## Sjekkliste

- [x] Koden kompilerer og bygger uten feil
- [x] Endringene er testet lokalt
- [x] Visuell sjekk av hover states, shadows og ikonfarger