### PR TITLE
fix(storybook): add GitHub Packages auth and workflow_dispatch to deploy workflow

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -3,6 +3,7 @@ name: Deploy Storybook to GitHub Pages
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: deploy-storybook-${{ github.ref }}


### PR DESCRIPTION
## Beskrivelse

Storybook deploy-workflowen feilet med `ERR_PNPM_FETCH_401` fordi `@navikt`-pakker fra GitHub Packages krevde autentisering som ikke var konfigurert.

## Endringer

- `deploy-storybook.yml`: Lagt til `registry-url: https://npm.pkg.github.com` i setup-node-steget
- `deploy-storybook.yml`: Lagt til `NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}` på pnpm install
- `deploy-storybook.yml`: Lagt til `workflow_dispatch` trigger for manuell kjøring

## Issue

Ingen issue — enkel config-fiks.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)