### PR TITLE
chore(ci): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploy-aktivitetskrav.yaml
+++ b/.github/workflows/deploy-aktivitetskrav.yaml
@@ -20,9 +20,9 @@ jobs:
       packages: "write"
 
     steps:
-      - uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd" # v5
-      - uses: "pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320" # v4
-      - uses: "actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444" # v5
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
+      - uses: "pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320" # v5.0.0
+      - uses: "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f" # v6.3.0
         with:
           node-version: 24
           registry-url: "https://npm.pkg.github.com"
@@ -95,7 +95,7 @@ jobs:
       id-token: "write"
     needs: [build, update-manifest-dev]
     steps:
-      - uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
       - name: "Deploy to dev"
         uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
         env:
@@ -112,7 +112,7 @@ jobs:
   #   needs: [build, update-manifest-prod]
 
   #   steps:
-  #     - uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
+  #     - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
   #     - name: "Deploy to prod"
   #       uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
   #       env:

--- a/.github/workflows/deploy-dialogmote.yaml
+++ b/.github/workflows/deploy-dialogmote.yaml
@@ -20,9 +20,9 @@ jobs:
       packages: "write"
 
     steps:
-      - uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd" # v5
-      - uses: "pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320" # v4
-      - uses: "actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444" # v5
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
+      - uses: "pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320" # v5.0.0
+      - uses: "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f" # v6.3.0
         with:
           node-version: 24
           registry-url: "https://npm.pkg.github.com"
@@ -95,7 +95,7 @@ jobs:
       id-token: "write"
     needs: [build, update-manifest-dev]
     steps:
-      - uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
       - name: "Deploy to dev"
         uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
         env:
@@ -112,7 +112,7 @@ jobs:
   #   needs: [build, update-manifest-prod]
 
   #   steps:
-  #     - uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
+  #     - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
   #     - name: "Deploy to prod"
   #       uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
   #       env:

--- a/.github/workflows/deploy-meroppfolging.yaml
+++ b/.github/workflows/deploy-meroppfolging.yaml
@@ -13,9 +13,9 @@ jobs:
       packages: "write"
 
     steps:
-      - uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd" # v5
-      - uses: "pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320" # v4
-      - uses: "actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444" # v5
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
+      - uses: "pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320" # v5.0.0
+      - uses: "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f" # v6.3.0
         with:
           node-version: 24
           registry-url: "https://npm.pkg.github.com"
@@ -88,7 +88,7 @@ jobs:
       id-token: "write"
     needs: [build, update-manifest-dev]
     steps:
-      - uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
       - name: "Deploy to dev"
         uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
         env:
@@ -105,7 +105,7 @@ jobs:
   #   needs: [build, update-manifest-prod]
 
   #   steps:
-  #     - uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
+  #     - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
   #     - name: "Deploy to prod"
   #       uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
   #       env:

--- a/.github/workflows/deploy-motebehov.yaml
+++ b/.github/workflows/deploy-motebehov.yaml
@@ -20,9 +20,9 @@ jobs:
       packages: "write"
 
     steps:
-      - uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd" # v5
-      - uses: "pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320" # v4
-      - uses: "actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444" # v5
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
+      - uses: "pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320" # v5.0.0
+      - uses: "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f" # v6.3.0
         with:
           node-version: 24
           registry-url: "https://npm.pkg.github.com"
@@ -95,7 +95,7 @@ jobs:
       id-token: "write"
     needs: [build, update-manifest-dev]
     steps:
-      - uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
       - name: "Deploy to dev"
         uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
         env:
@@ -112,7 +112,7 @@ jobs:
   #   needs: [build, update-manifest-prod]
 
   #   steps:
-  #     - uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4
+  #     - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
   #     - name: "Deploy to prod"
   #       uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
   #       env:

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -16,19 +16,19 @@ jobs:
       contents: read
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '24'
           cache: pnpm
           registry-url: "https://npm.pkg.github.com"
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - run: pnpm install --frozen-lockfile
         env:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
       - run: pnpm run build-storybook
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: storybook-static
 
@@ -44,4 +44,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Beskrivelse

Oppdaterer alle SHA-pinnede GitHub Actions til nyeste versjoner for å løse Node.js 20 deprecation-advarsler. Actions vil bli tvunget til Node.js 24 fra juni 2026.

## Endringer

- `actions/checkout`: v4/v5 → v6.0.2
- `actions/setup-node`: v4/v5 → v6.3.0
- `pnpm/action-setup`: v4 → v5.0.0
- `actions/upload-pages-artifact`: v3 → v4.0.0
- `actions/configure-pages`: oppdatert kommentar til v5.0.0
- `actions/deploy-pages`: oppdatert kommentar til v4.0.5

Oppdatert i alle 5 workflow-filer:
- `deploy-dialogmote.yaml`
- `deploy-aktivitetskrav.yaml`
- `deploy-meroppfolging.yaml`
- `deploy-motebehov.yaml`
- `deploy-storybook.yml`

## Issue

Closes #55

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)