### PR TITLE
feat(storybook): add meroppfolging stories and Norwegian display names

### DIFF
--- a/microfrontends/aktivitetskrav/src/stories/Aktivitetskrav.stories.tsx
+++ b/microfrontends/aktivitetskrav/src/stories/Aktivitetskrav.stories.tsx
@@ -31,26 +31,32 @@ const resolveStoryArgs = (...args: Parameters<typeof resolvePanel>) => {
 };
 
 export const Ny: Story = {
+  name: "Ny",
   args: resolveStoryArgs(createNyVurdering(), href, now),
 };
 
 export const NyVurdering: Story = {
+  name: "Ny vurdering",
   args: resolveStoryArgs(createNyVurderingStatus(), href, now),
 };
 
 export const Avvent: Story = {
+  name: "Avvent",
   args: resolveStoryArgs(createAvvent(), href, now),
 };
 
 export const Unntak: Story = {
+  name: "Unntak",
   args: resolveStoryArgs(createUnntak(), href, now),
 };
 
 export const Oppfylt: Story = {
+  name: "Oppfylt",
   args: resolveStoryArgs(createOppfylt(), href, now),
 };
 
 export const ForhandsvarselForFrist: Story = {
+  name: "Forhåndsvarsel — før frist",
   args: resolveStoryArgs(
     createForhandsvarsel({ fristDato: "2024-07-01T00:00:00.000Z" }),
     href,
@@ -59,6 +65,7 @@ export const ForhandsvarselForFrist: Story = {
 };
 
 export const ForhandsvarselUtenJournalpost: Story = {
+  name: "Forhåndsvarsel — uten journalpost",
   args: resolveStoryArgs(
     createForhandsvarsel({ journalpostId: undefined }),
     href,
@@ -67,6 +74,7 @@ export const ForhandsvarselUtenJournalpost: Story = {
 };
 
 export const ForhandsvarselEtterFrist: Story = {
+  name: "Forhåndsvarsel — etter frist",
   args: resolveStoryArgs(
     createForhandsvarsel({ fristDato: "2024-05-01T00:00:00.000Z" }),
     href,
@@ -75,5 +83,6 @@ export const ForhandsvarselEtterFrist: Story = {
 };
 
 export const IkkeAktuell: Story = {
+  name: "Ikke aktuell",
   args: resolveStoryArgs(createIkkeAktuell(), href, now),
 };

--- a/microfrontends/dialogmote/src/stories/Dialogmote.stories.tsx
+++ b/microfrontends/dialogmote/src/stories/Dialogmote.stories.tsx
@@ -20,6 +20,7 @@ const createSvar = (svarType: SvarTypeDto): NonNullable<BrevDto["svar"]> => ({
 });
 
 export const InnkaltIkkeSvart: Story = {
+  name: "Innkalt — ikke svart",
   args: resolvePanel(
     createBrev({ brevType: "INNKALT", svar: null, lestDato: null }),
     href,
@@ -27,6 +28,7 @@ export const InnkaltIkkeSvart: Story = {
 };
 
 export const InnkaltTakketJa: Story = {
+  name: "Innkalt — takket ja",
   args: resolvePanel(
     createBrev({ brevType: "INNKALT", svar: createSvar("KOMMER") }),
     href,
@@ -34,6 +36,7 @@ export const InnkaltTakketJa: Story = {
 };
 
 export const InnkaltOnskerAvlyse: Story = {
+  name: "Innkalt — ønsker avlyse",
   args: resolvePanel(
     createBrev({ brevType: "INNKALT", svar: createSvar("KOMMER_IKKE") }),
     href,
@@ -41,6 +44,7 @@ export const InnkaltOnskerAvlyse: Story = {
 };
 
 export const InnkaltOnskerEndre: Story = {
+  name: "Innkalt — ønsker endre",
   args: resolvePanel(
     createBrev({ brevType: "INNKALT", svar: createSvar("NYTT_TID_STED") }),
     href,
@@ -48,6 +52,7 @@ export const InnkaltOnskerEndre: Story = {
 };
 
 export const NyttTidStedIkkeSvart: Story = {
+  name: "Nytt tid/sted — ikke svart",
   args: resolvePanel(
     createBrev({ brevType: "NYTT_TID_STED", svar: null, lestDato: null }),
     href,
@@ -55,6 +60,7 @@ export const NyttTidStedIkkeSvart: Story = {
 };
 
 export const NyttTidStedTakketJa: Story = {
+  name: "Nytt tid/sted — takket ja",
   args: resolvePanel(
     createBrev({ brevType: "NYTT_TID_STED", svar: createSvar("KOMMER") }),
     href,
@@ -62,6 +68,7 @@ export const NyttTidStedTakketJa: Story = {
 };
 
 export const NyttTidStedOnskerAvlyse: Story = {
+  name: "Nytt tid/sted — ønsker avlyse",
   args: resolvePanel(
     createBrev({
       brevType: "NYTT_TID_STED",
@@ -72,6 +79,7 @@ export const NyttTidStedOnskerAvlyse: Story = {
 };
 
 export const NyttTidStedOnskerEndre: Story = {
+  name: "Nytt tid/sted — ønsker endre",
   args: resolvePanel(
     createBrev({
       brevType: "NYTT_TID_STED",

--- a/microfrontends/meroppfolging/src/stories/Meroppfolging.stories.tsx
+++ b/microfrontends/meroppfolging/src/stories/Meroppfolging.stories.tsx
@@ -72,10 +72,12 @@ const kartleggingSvart: MeroppfolgingStatusDto = {
 };
 
 export const SenOppfolgingIkkeSvart: Story = {
+  name: "Sen oppfølging — ikke svart",
   args: resolveStoryArgs(senOppfolgingIkkeSvart, sspsUrl, kartleggingUrl, now),
 };
 
 export const SenOppfolgingTrengerOppfolging: Story = {
+  name: "Sen oppfølging — trenger oppfølging",
   args: resolveStoryArgs(
     senOppfolgingTrengerOppfolging,
     sspsUrl,
@@ -85,6 +87,7 @@ export const SenOppfolgingTrengerOppfolging: Story = {
 };
 
 export const SenOppfolgingTrengerIkkeOppfolging: Story = {
+  name: "Sen oppfølging — trenger ikke oppfølging",
   args: resolveStoryArgs(
     senOppfolgingTrengerIkkeOppfolging,
     sspsUrl,
@@ -94,9 +97,11 @@ export const SenOppfolgingTrengerIkkeOppfolging: Story = {
 };
 
 export const KartleggingIkkeSvart: Story = {
+  name: "Kartlegging — ikke svart",
   args: resolveStoryArgs(kartleggingIkkeSvart, sspsUrl, kartleggingUrl, now),
 };
 
 export const KartleggingSvart: Story = {
+  name: "Kartlegging — svart",
   args: resolveStoryArgs(kartleggingSvart, sspsUrl, kartleggingUrl, now),
 };

--- a/microfrontends/motebehov/src/stories/Motebehov.stories.tsx
+++ b/microfrontends/motebehov/src/stories/Motebehov.stories.tsx
@@ -12,5 +12,6 @@ type Story = StoryObj<typeof meta>;
 const href = "/syk/dialogmoter/sykmeldt";
 
 export const TrengerDuDialogmote: Story = {
+  name: "Trenger du dialogmøte?",
   args: resolvePanel(href),
 };


### PR DESCRIPTION
## Beskrivelse

Legger til Storybook-stories for meroppfølging-mikrofrontenden, og legger til norske visningsnavn (`name`-property) på alle eksisterende stories.

## Endringer

- `microfrontends/meroppfolging/src/stories/Meroppfolging.stories.tsx`: Ny fil med 5 stories som dekker alle synlige statuser (sen oppfølging og kartlegging)
- `microfrontends/aktivitetskrav/src/stories/Aktivitetskrav.stories.tsx`: Lagt til norske `name`-properties
- `microfrontends/dialogmote/src/stories/Dialogmote.stories.tsx`: Lagt til norske `name`-properties
- `microfrontends/motebehov/src/stories/Motebehov.stories.tsx`: Lagt til norsk `name`-property

## Issue

Closes #78

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)