### PR TITLE
fix(shared): prevent MainPanel content overflow

### DIFF
--- a/packages/shared/src/components/MainPanel.module.css
+++ b/packages/shared/src/components/MainPanel.module.css
@@ -20,7 +20,6 @@
   display: flex;
   text-decoration: none;
   flex-direction: row;
-  width: 100%;
   align-items: center;
   padding: var(--ax-space-12) var(--ax-space-16) var(--ax-space-16);
 


### PR DESCRIPTION
## Beskrivelse

Denne PR-en fikser layout-feilen i `MainPanel` der body-tekst kunne flyte utenfor panelet i stories med fast bredde. Årsaken var at innholdsraden hadde `width: 100%` i en flekslayout, som presset innholdet utover tilgjengelig plass.

## Endringer

- `packages/shared/src/components/MainPanel.module.css`: fjernet `width: 100%` fra `.contentRow` slik at tekst og ikon kan tilpasse seg panelbredden uten overlapp/overflow
- Verifisert med eksisterende bygg for workspace-prosjektene (`pnpm -r --if-present build`)

## Issue

Closes #85

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
