### PR TITLE
feat(ci): add reusable merge-gate workflows

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -2,6 +2,9 @@ name: Reusable CI
 
 on:
   workflow_call:
+    secrets:
+      npm-auth-token:
+        required: true
 
 env:
   NODE_VERSION: '24'
@@ -24,7 +27,7 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
       - run: pnpm install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.npm-auth-token }}
       - run: pnpm run lint
       - run: pnpm run check
 
@@ -45,7 +48,7 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
       - run: pnpm install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.npm-auth-token }}
       - run: pnpm run test
 
   build-storybook:
@@ -65,7 +68,7 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
       - run: pnpm install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.npm-auth-token }}
       - run: pnpm run build-storybook
 
   build-microfrontends:
@@ -97,5 +100,5 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
       - run: pnpm install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.npm-auth-token }}
       - run: pnpm run ${{ matrix.script }}

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -24,7 +24,7 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
       - run: pnpm install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ github.token }}
       - run: pnpm run lint
       - run: pnpm run check
 
@@ -45,7 +45,7 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
       - run: pnpm install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ github.token }}
       - run: pnpm run test
 
   build-storybook:
@@ -65,7 +65,7 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
       - run: pnpm install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ github.token }}
       - run: pnpm run build-storybook
 
   build-microfrontends:
@@ -97,5 +97,5 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
       - run: pnpm install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ github.token }}
       - run: pnpm run ${{ matrix.script }}

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -1,0 +1,100 @@
+name: Reusable CI
+
+on:
+  workflow_call:
+    secrets:
+      READER_TOKEN:
+        required: true
+
+env:
+  NODE_VERSION: '24'
+
+jobs:
+  lint-and-checks:
+    name: Lint and checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          registry-url: "https://npm.pkg.github.com"
+      - run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+      - run: pnpm run lint
+      - run: pnpm run check
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          registry-url: "https://npm.pkg.github.com"
+      - run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+      - run: pnpm run test
+
+  build-storybook:
+    name: Build Storybook
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          registry-url: "https://npm.pkg.github.com"
+      - run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+      - run: pnpm run build-storybook
+
+  build-microfrontends:
+    name: Build ${{ matrix.microfrontend }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - microfrontend: dialogmote
+            script: build:dialogmote-microfrontend
+          - microfrontend: aktivitetskrav
+            script: build:aktivitetskrav-microfrontend
+          - microfrontend: meroppfolging
+            script: build:meroppfolging-microfrontend
+          - microfrontend: motebehov
+            script: build:motebehov-microfrontend
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          registry-url: "https://npm.pkg.github.com"
+      - run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+      - run: pnpm run ${{ matrix.script }}

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -2,9 +2,6 @@ name: Reusable CI
 
 on:
   workflow_call:
-    secrets:
-      READER_TOKEN:
-        required: true
 
 env:
   NODE_VERSION: '24'
@@ -15,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -26,7 +24,7 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
       - run: pnpm install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm run lint
       - run: pnpm run check
 
@@ -35,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -46,7 +45,7 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
       - run: pnpm install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm run test
 
   build-storybook:
@@ -54,6 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -65,7 +65,7 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
       - run: pnpm install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm run build-storybook
 
   build-microfrontends:
@@ -73,6 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -96,5 +97,5 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
       - run: pnpm install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm run ${{ matrix.script }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
   ci:
     name: Reusable CI
     uses: ./.github/workflows/ci-reusable.yml
+    secrets:
+      npm-auth-token: ${{ secrets.READER_TOKEN }}
 
   merge-gate:
     name: Merge gate

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,25 +33,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          results=("ci=${{ needs.ci.result }}")
-          printf '%s\n' "${results[@]}"
+          result="ci=${{ needs.ci.result }}"
+          printf '%s\n' "$result"
 
-          for result in "${results[@]}"; do
-            status="${result#*=}"
-
-            case "$status" in
-              success)
-                ;;
-              cancelled)
-                echo "::error::Required job was cancelled: $result. Likely causes: a newer push cancelled an in-flight run due to concurrency.cancel-in-progress, the run was cancelled manually, or this merge queue attempt was superseded or re-queued. Re-run CI from the latest commit or merge queue entry."
-                exit 1
-                ;;
-              skipped)
-                echo "Accepting skipped job result: $result"
-                ;;
-              *)
-                echo "::error::Required job failed: $result"
-                exit 1
-                ;;
-            esac
-          done
+          case "${{ needs.ci.result }}" in
+            success)
+              ;;
+            cancelled)
+              echo "::error::Required job was cancelled: $result. Likely causes: a newer push cancelled an in-flight run due to concurrency.cancel-in-progress, the run was cancelled manually, or this merge queue attempt was superseded or re-queued. Re-run CI from the latest commit or merge queue entry."
+              exit 1
+              ;;
+            skipped)
+              echo "Accepting skipped job result: $result"
+              ;;
+            *)
+              echo "::error::Required job failed: $result"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  reusable-ci:
+  ci:
     name: Reusable CI
     uses: ./.github/workflows/ci-reusable.yml
     secrets: inherit
@@ -22,7 +22,7 @@ jobs:
   merge-gate:
     name: Merge gate
     needs:
-      - reusable-ci
+      - ci
     if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions: {}
@@ -32,9 +32,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          results=(
-            "reusable-ci=${{ needs.reusable-ci.result }}"
-          )
+          results=("ci=${{ needs.ci.result }}")
           printf '%s\n' "${results[@]}"
 
           for result in "${results[@]}"; do
@@ -48,8 +46,7 @@ jobs:
                 exit 1
                 ;;
               skipped)
-                echo "::error::Required job was unexpectedly skipped: $result"
-                exit 1
+                echo "Accepting skipped job result: $result"
                 ;;
               *)
                 echo "::error::Required job failed: $result"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -17,7 +18,6 @@ jobs:
   ci:
     name: Reusable CI
     uses: ./.github/workflows/ci-reusable.yml
-    secrets: inherit
 
   merge-gate:
     name: Merge gate

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
               success)
                 ;;
               cancelled)
-                echo "::error::Required job was cancelled: $result"
+                echo "::error::Required job was cancelled: $result. Likely causes: a newer push cancelled an in-flight run due to concurrency.cancel-in-progress, the run was cancelled manually, or this merge queue attempt was superseded or re-queued. Re-run CI from the latest commit or merge queue entry."
                 exit 1
                 ;;
               skipped)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  pull_request:
+  merge_group:
+    types:
+      - checks_requested
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  reusable-ci:
+    name: Reusable CI
+    uses: ./.github/workflows/ci-reusable.yml
+    secrets: inherit
+
+  merge-gate:
+    name: Merge gate
+    needs:
+      - reusable-ci
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Check required jobs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          results=(
+            "reusable-ci=${{ needs.reusable-ci.result }}"
+          )
+          printf '%s\n' "${results[@]}"
+
+          for result in "${results[@]}"; do
+            status="${result#*=}"
+
+            case "$status" in
+              success)
+                ;;
+              cancelled)
+                echo "::error::Required job was cancelled: $result"
+                exit 1
+                ;;
+              skipped)
+                echo "::error::Required job was unexpectedly skipped: $result"
+                exit 1
+                ;;
+              *)
+                echo "::error::Required job failed: $result"
+                exit 1
+                ;;
+            esac
+          done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
   merge_group:
     types:
       - checks_requested
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -13,3 +13,5 @@ jobs:
   ci:
     name: Reusable CI
     uses: ./.github/workflows/ci-reusable.yml
+    secrets:
+      npm-auth-token: ${{ secrets.READER_TOKEN }}

--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -1,0 +1,19 @@
+name: Main CI
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: Reusable CI
+    uses: ./.github/workflows/ci-reusable.yml

--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -9,10 +9,6 @@ permissions:
   contents: read
   packages: read
 
-concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   ci:
     name: Reusable CI

--- a/mise.toml
+++ b/mise.toml
@@ -76,7 +76,8 @@ run = ["pnpm run check",
 "pnpm run build:dialogmote-microfrontend",
 "pnpm run build:aktivitetskrav-microfrontend",
 "pnpm run build:meroppfolging-microfrontend",
-"pnpm run build:motebehov-microfrontend"
+"pnpm run build:motebehov-microfrontend",
+"pnpm run build-storybook"
 ]
 
 [tasks.storybook]


### PR DESCRIPTION
## Beskrivelse

Legger til en egen CI merge gate uten deploy, og strukturerer workflowene slik at kvalitetssjekkene kan gjenbrukes for både PR/merge queue og post-merge på `main`.

## Endringer

- `.github/workflows/ci-reusable.yml`: ny reusable workflow for lint, check, test, Storybook-build og bygg av alle microfrontends
- `.github/workflows/ci.yaml`: ny CI-entrypoint for `pull_request`, `merge_group` og manuell kjøring med stabil `Merge gate`-status og tydeligere håndtering av cancelled/skipped-resultater
- `.github/workflows/main-ci.yaml`: ny post-merge CI på `push` til `main` som gjenbruker `ci-reusable.yml`
- `mise.toml`: oppdaterer `mise verify` slik at lokal verifikasjon også inkluderer Storybook-build
- workflow-auth og package permissions er strammet inn til built-in token + eksplisitt `packages: read`

## Issue

Closes #77

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
