### PR TITLE
ci(dependabot): add automerge support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+
+registries:
+  github-npm:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{ secrets.READER_TOKEN }}
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    registries:
+      - github-npm
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    groups:
+      navikt:
+        patterns:
+          - "@navikt/*"
+      astro:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,20 @@
+name: Dependabot auto-approve and auto-merge
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions: {}
+
+jobs:
+  automerge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: navikt/teamesyfo-github-actions-workflows/.github/workflows/dependabot-automerge.yaml@main
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.AUTOMERGE_APP_PRIVATE_KEY }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -7,8 +7,6 @@ on:
       - reopened
       - synchronize
 
-permissions: {}
-
 jobs:
   automerge:
     if: ${{ github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   automerge:
-    if: ${{ github.actor == 'dependabot[bot]' }}
     permissions:
       contents: write
       pull-requests: write

--- a/README.md
+++ b/README.md
@@ -94,6 +94,34 @@ flowchart LR
 
 > **Merk:** Prod-deploy er foreløpig deaktivert. Kun dev-gcp er aktivt.
 
+## Dependabot og automerge
+
+Repoet bruker `.github/dependabot.yml` for ukentlige oppdateringer av rot-workspace-et og GitHub Actions. Trygg auto-godkjenning og auto-merge styres av `.github/workflows/dependabot-automerge.yml`, som kaller teamets reusable workflow fra `navikt/teamesyfo-github-actions-workflows`.
+
+### Forventet policy
+
+| Oppdateringstype | Behandles automatisk |
+|------------------|----------------------|
+| GitHub Actions | Ja, inkludert major |
+| npm patch | Ja |
+| npm minor | Ja |
+| npm major | Nei, manuell vurdering |
+
+### Påkrevd GitHub-oppsett
+
+Følgende må være på plass for at Dependabot-PR-er skal kunne auto-merges trygt:
+
+1. GitHub App-en `teamesyfo-automerge` må ha repository access til repoet.
+2. Dependabot må ha tilgang til `AUTOMERGE_APP_PRIVATE_KEY` som Dependabot secret.
+3. Dependabot må ha tilgang til `READER_TOKEN` for å kunne lese pakker fra `npm.pkg.github.com`.
+4. Repository settings må ha `Allow auto-merge` aktivert.
+5. Settings → Actions → General må bruke `Read and write permissions` og `Allow GitHub Actions to create and approve pull requests`.
+6. Ruleset eller branch protection på `main` må kreve status checken `Merge gate`, siden den er CI-gaten for både `pull_request` og `merge_group`.
+
+### Verifisering
+
+Når oppsettet er aktivt, skal en Dependabot-PR for patch/minor enten auto-godkjennes og legges i merge queue eller vente på at `Merge gate` blir grønn. Major-oppdateringer utenfor GitHub Actions skal bli stående til manuell vurdering.
+
 ## Backend-integrasjoner
 
 ### Dialogmote

--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ Følgende må være på plass for at Dependabot-PR-er skal kunne auto-merges try
 2. Dependabot må ha tilgang til `AUTOMERGE_APP_PRIVATE_KEY` som Dependabot secret.
 3. Dependabot må ha tilgang til `READER_TOKEN` for å kunne lese pakker fra `npm.pkg.github.com`.
 4. Repository settings må ha `Allow auto-merge` aktivert.
-5. Settings → Actions → General må bruke `Read and write permissions` og `Allow GitHub Actions to create and approve pull requests`.
+5. Settings → Actions → General må ha `Allow GitHub Actions to create and approve pull requests` aktivert.
 6. Ruleset eller branch protection på `main` må kreve status checken `Merge gate`, siden den er CI-gaten for både `pull_request` og `merge_group`.
+
+Teamets reusable workflow ber om write-scope eksplisitt i jobben. I dette repoet er standard workflow-permissions forelopig `read`, og org-policy blokkerer endring av default til `write`.
 
 ### Verifisering
 

--- a/README.md
+++ b/README.md
@@ -94,36 +94,6 @@ flowchart LR
 
 > **Merk:** Prod-deploy er foreløpig deaktivert. Kun dev-gcp er aktivt.
 
-## Dependabot og automerge
-
-Repoet bruker `.github/dependabot.yml` for ukentlige oppdateringer av rot-workspace-et og GitHub Actions. Trygg auto-godkjenning og auto-merge styres av `.github/workflows/dependabot-automerge.yml`, som kaller teamets reusable workflow fra `navikt/teamesyfo-github-actions-workflows`.
-
-### Forventet policy
-
-| Oppdateringstype | Behandles automatisk |
-|------------------|----------------------|
-| GitHub Actions | Ja, inkludert major |
-| npm patch | Ja |
-| npm minor | Ja |
-| npm major | Nei, manuell vurdering |
-
-### Påkrevd GitHub-oppsett
-
-Følgende må være på plass for at Dependabot-PR-er skal kunne auto-merges trygt:
-
-1. GitHub App-en `teamesyfo-automerge` må ha repository access til repoet.
-2. Dependabot må ha tilgang til `AUTOMERGE_APP_PRIVATE_KEY` som Dependabot secret.
-3. Dependabot må ha tilgang til `READER_TOKEN` for å kunne lese pakker fra `npm.pkg.github.com`.
-4. Repository settings må ha `Allow auto-merge` aktivert.
-5. Settings → Actions → General må ha `Allow GitHub Actions to create and approve pull requests` aktivert.
-6. Ruleset eller branch protection på `main` må kreve status checken `Merge gate`, siden den er CI-gaten for både `pull_request` og `merge_group`.
-
-Teamets reusable workflow ber om write-scope eksplisitt i jobben. I dette repoet er standard workflow-permissions forelopig `read`, og org-policy blokkerer endring av default til `write`.
-
-### Verifisering
-
-Når oppsettet er aktivt, skal en Dependabot-PR for patch/minor enten auto-godkjennes og legges i merge queue eller vente på at `Merge gate` blir grønn. Major-oppdateringer utenfor GitHub Actions skal bli stående til manuell vurdering.
-
 ## Backend-integrasjoner
 
 ### Dialogmote


### PR DESCRIPTION
## Beskrivelse

Legger til repo-oppsettet som trengs for Dependabot-oppdateringer og Team eSyfos felles automerge-workflow.

## Endringer

- `.github/dependabot.yml`: konfigurerer ukentlige Dependabot-oppdateringer for root `npm` og `github-actions`, inkludert GitHub Packages-registry
- `.github/workflows/dependabot-automerge.yml`: kaller reusable workflowen i `navikt/teamesyfo-github-actions-workflows`

## Issue

Closes #48

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
