### PR TITLE
ci(actions): reuse microfrontend deploy workflow

### DIFF
--- a/.github/workflows/deploy-aktivitetskrav.yaml
+++ b/.github/workflows/deploy-aktivitetskrav.yaml
@@ -6,6 +6,7 @@ on:
       - "main"
     paths:
       - "microfrontends/aktivitetskrav/**"
+      - "packages/shared/**"
       - "pnpm-lock.yaml"
       - "package.json"
   workflow_dispatch:

--- a/.github/workflows/deploy-aktivitetskrav.yaml
+++ b/.github/workflows/deploy-aktivitetskrav.yaml
@@ -1,4 +1,5 @@
-name: "Deploy dev&prod"
+name: Deploy aktivitetskrav
+
 on:
   push:
     branches:
@@ -10,112 +11,20 @@ on:
       - "package.json"
 
 jobs:
-  build:
-    name: "build"
-    runs-on: "ubuntu-latest"
-
-    permissions:
-      contents: "read"
-      id-token: "write"
-      packages: "write"
-
-    steps:
-      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
-      - uses: "pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320" # v5.0.0
-      - uses: "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f" # v6.3.0
-        with:
-          node-version: 24
-          registry-url: "https://npm.pkg.github.com"
-          cache: "pnpm"
-
-      - name: "Install dependencies"
-        run: "pnpm install --frozen-lockfile"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
-
-      - name: "Run tests"
-        run: "pnpm test"
-
-      - name: "Build application"
-        run: "pnpm run build:aktivitetskrav-microfrontend"
-
-      - name: "Upload to cdn"
-        uses: "nais/deploy/actions/cdn-upload/v2@437e4adfe270e3f1c98fd0eed7f86ecf0e0873db" # master
-        with:
-          team: team-esyfo # Change this to your team name
-          source: ./microfrontends/aktivitetskrav/dist/client/_astro
-          destination: "aktivitetskrav-microfrontend" # Change this to your application name
-
-      - name: "Build and push"
-        uses: "nais/docker-build-push@45d352fb62fb52ccb5ff6cba22c047fa02b35321" # v0
-        id: docker-build-push
-        with:
-          team: team-esyfo # Change this to your team name
-          dockerfile: ./microfrontends/aktivitetskrav/Dockerfile
-
-    outputs:
-      image: ${{ steps.docker-build-push.outputs.image }}
-
-  update-manifest-dev:
-    permissions:
-      contents: "read"
-      id-token: "write"
-    uses: "navikt/tms-deploy/.github/workflows/oppdater-mikrofrontend-manifest-v3.yaml@67dc876fb9e1a0b115e47a36fd46a1c7b0064d4c" # main
-    needs: build
+  deploy:
+    uses: ./.github/workflows/deploy-microfrontend-reusable.yml
     with:
-      id: "syfo-aktivitetskrav" # Change this to your microfrontend id.
-      url: "http://aktivitetskrav-microfrontend.min-side" # Change the url to contain your application name. Example: http://my-app.namespace
-      appname: "aktivitetskrav-microfrontend" # Change this to your application name
-      namespace: "team-esyfo" # Change this to your namespace
-      cluster: dev-gcp
-      commitmsg: ${{ github.event.head_commit.message}}
-      fallback: "fallback" # Should containt the path to the fallback page after src/pages/[locale]/... Only needs to be changed if you move the fallback in the pages structure
-      ssr: true
+      microfrontend_name: "aktivitetskrav"
+      build_script: "build:aktivitetskrav-microfrontend"
+      dockerfile: "./microfrontends/aktivitetskrav/Dockerfile"
+      cdn_source: "./microfrontends/aktivitetskrav/dist/client/_astro"
+      cdn_destination: "aktivitetskrav-microfrontend"
+      manifest_id: "syfo-aktivitetskrav"
+      app_name: "aktivitetskrav-microfrontend"
+      dev_manifest_url: "http://aktivitetskrav-microfrontend.min-side"
+      dev_namespace: "team-esyfo"
+      fallback: "fallback"
+      dev_resource: "microfrontends/aktivitetskrav/nais/dev-gcp/nais.yaml"
+      commit_message: ${{ github.event.head_commit.message }}
+      enable_prod: false
     secrets: inherit
-
-  # update-manifest-prod:
-  #   if: github.ref == 'refs/heads/main'
-  #   uses: "navikt/tms-deploy/.github/workflows/oppdater-mikrofrontend-manifest-v3.yaml@67dc876fb9e1a0b115e47a36fd46a1c7b0064d4c" # main
-  #   needs: build
-  #   with:
-  #     id: "syfo-aktivitetskrav"
-  #     url: "http://aktivitetskrav-microfrontend.min-side"
-  #     appname: "aktivitetskrav-microfrontend"
-  #     namespace: "min-side"
-  #     cluster: prod-gcp
-  #     commitmsg: ${{ github.event.head_commit.message}}
-  #     fallback: "fallback" # Should containt the path to the fallback page after src/pages/[locale]/...
-  #     ssr: true
-  #   secrets: inherit
-
-  deploy-dev:
-    runs-on: "ubuntu-latest"
-    permissions:
-      contents: "read"
-      id-token: "write"
-    needs: [build, update-manifest-dev]
-    steps:
-      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
-      - name: "Deploy to dev"
-        uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
-        env:
-          CLUSTER: dev-gcp
-          RESOURCE: microfrontends/aktivitetskrav/nais/dev-gcp/nais.yaml
-          VAR: image=${{ needs.build.outputs.image }},version=${{ github.sha }}
-
-  # deploy-prod:
-  #   if: github.ref == 'refs/heads/main'
-  #   runs-on: "ubuntu-latest"
-  #   permissions:
-  #     contents: "read"
-  #     id-token: "write"
-  #   needs: [build, update-manifest-prod]
-
-  #   steps:
-  #     - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
-  #     - name: "Deploy to prod"
-  #       uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
-  #       env:
-  #         CLUSTER: prod-gcp
-  #         RESOURCE: microfrontends/aktivitetskrav/nais/prod-gcp/nais.yaml
-  #         VAR: image=${{ needs.build.outputs.image }},version=${{ github.sha }}

--- a/.github/workflows/deploy-aktivitetskrav.yaml
+++ b/.github/workflows/deploy-aktivitetskrav.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - "main"
-      - "deploy-aktivitetskrav"
     paths:
       - "microfrontends/aktivitetskrav/**"
       - "pnpm-lock.yaml"
       - "package.json"
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-aktivitetskrav.yaml
+++ b/.github/workflows/deploy-aktivitetskrav.yaml
@@ -22,9 +22,7 @@ jobs:
       manifest_id: "syfo-aktivitetskrav"
       app_name: "aktivitetskrav-microfrontend"
       dev_manifest_url: "http://aktivitetskrav-microfrontend.min-side"
-      dev_namespace: "team-esyfo"
-      fallback: "fallback"
+      namespace: "team-esyfo"
       dev_resource: "microfrontends/aktivitetskrav/nais/dev-gcp/nais.yaml"
-      commit_message: ${{ github.event.head_commit.message }}
       enable_prod: false
     secrets: inherit

--- a/.github/workflows/deploy-aktivitetskrav.yaml
+++ b/.github/workflows/deploy-aktivitetskrav.yaml
@@ -22,7 +22,6 @@ jobs:
       manifest_id: "syfo-aktivitetskrav"
       app_name: "aktivitetskrav-microfrontend"
       dev_manifest_url: "http://aktivitetskrav-microfrontend.min-side"
-      namespace: "team-esyfo"
       dev_resource: "microfrontends/aktivitetskrav/nais/dev-gcp/nais.yaml"
       enable_prod: false
     secrets: inherit

--- a/.github/workflows/deploy-aktivitetskrav.yaml
+++ b/.github/workflows/deploy-aktivitetskrav.yaml
@@ -18,9 +18,8 @@ jobs:
       build_script: "build:aktivitetskrav-microfrontend"
       dockerfile: "./microfrontends/aktivitetskrav/Dockerfile"
       cdn_source: "./microfrontends/aktivitetskrav/dist/client/_astro"
-      cdn_destination: "aktivitetskrav-microfrontend"
       manifest_id: "syfo-aktivitetskrav"
-      app_name: "aktivitetskrav-microfrontend"
+      application_name: "aktivitetskrav-microfrontend"
       dev_manifest_url: "http://aktivitetskrav-microfrontend.min-side"
       dev_resource: "microfrontends/aktivitetskrav/nais/dev-gcp/nais.yaml"
       enable_prod: false

--- a/.github/workflows/deploy-dialogmote.yaml
+++ b/.github/workflows/deploy-dialogmote.yaml
@@ -1,4 +1,5 @@
-name: "Deploy dev&prod"
+name: Deploy dialogmote
+
 on:
   push:
     branches:
@@ -10,112 +11,20 @@ on:
       - "package.json"
 
 jobs:
-  build:
-    name: "build"
-    runs-on: "ubuntu-latest"
-
-    permissions:
-      contents: "read"
-      id-token: "write"
-      packages: "write"
-
-    steps:
-      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
-      - uses: "pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320" # v5.0.0
-      - uses: "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f" # v6.3.0
-        with:
-          node-version: 24
-          registry-url: "https://npm.pkg.github.com"
-          cache: "pnpm"
-
-      - name: "Install dependencies"
-        run: "pnpm install --frozen-lockfile"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
-
-      - name: "Run tests"
-        run: "pnpm test"
-
-      - name: "Build application"
-        run: "pnpm run build:dialogmote-microfrontend"
-
-      - name: "Upload to cdn"
-        uses: "nais/deploy/actions/cdn-upload/v2@437e4adfe270e3f1c98fd0eed7f86ecf0e0873db" # master
-        with:
-          team: team-esyfo # Change this to your team name
-          source: ./microfrontends/dialogmote/dist/client/_astro
-          destination: "dialogmote-microfrontend" # Change this to your application name
-
-      - name: "Build and push"
-        uses: "nais/docker-build-push@45d352fb62fb52ccb5ff6cba22c047fa02b35321" # v0
-        id: docker-build-push
-        with:
-          team: team-esyfo # Change this to your team name
-          dockerfile: ./microfrontends/dialogmote/Dockerfile
-
-    outputs:
-      image: ${{ steps.docker-build-push.outputs.image }}
-
-  update-manifest-dev:
-    permissions:
-      contents: "read"
-      id-token: "write"
-    uses: "navikt/tms-deploy/.github/workflows/oppdater-mikrofrontend-manifest-v3.yaml@67dc876fb9e1a0b115e47a36fd46a1c7b0064d4c" # main
-    needs: build
+  deploy:
+    uses: ./.github/workflows/deploy-microfrontend-reusable.yml
     with:
-      id: "syfo-dialog" # Change this to your microfrontend id.
-      url: "http://dialogmote-microfrontend.min-side" # Change the url to contain your application name. Example: http://my-app.namespace
-      appname: "dialogmote-microfrontend" # Change this to your application name
-      namespace: "team-esyfo" # Change this to your namespace
-      cluster: dev-gcp
-      commitmsg: ${{ github.event.head_commit.message}}
-      fallback: "fallback" # Should containt the path to the fallback page after src/pages/[locale]/... Only needs to be changed if you move the fallback in the pages structure
-      ssr: true
+      microfrontend_name: "dialogmote"
+      build_script: "build:dialogmote-microfrontend"
+      dockerfile: "./microfrontends/dialogmote/Dockerfile"
+      cdn_source: "./microfrontends/dialogmote/dist/client/_astro"
+      cdn_destination: "dialogmote-microfrontend"
+      manifest_id: "syfo-dialog"
+      app_name: "dialogmote-microfrontend"
+      dev_manifest_url: "http://dialogmote-microfrontend.min-side"
+      dev_namespace: "team-esyfo"
+      fallback: "fallback"
+      dev_resource: "microfrontends/dialogmote/nais/dev-gcp/nais.yaml"
+      commit_message: ${{ github.event.head_commit.message }}
+      enable_prod: false
     secrets: inherit
-
-  # update-manifest-prod:
-  #   if: github.ref == 'refs/heads/main'
-  #   uses: "navikt/tms-deploy/.github/workflows/oppdater-mikrofrontend-manifest-v3.yaml@67dc876fb9e1a0b115e47a36fd46a1c7b0064d4c" # main
-  #   needs: build
-  #   with:
-  #     id: "syfo-dialog"
-  #     url: "http://tms-microfrontend-template-ssr.min-side"
-  #     appname: "tms-microfrontend-template-ssr"
-  #     namespace: "team-namespace"
-  #     cluster: prod-gcp
-  #     commitmsg: ${{ github.event.head_commit.message}}
-  #     fallback: "fallback" # Should containt the path to the fallback page after src/pages/[locale]/...
-  #     ssr: true
-  #   secrets: inherit
-
-  deploy-dev:
-    runs-on: "ubuntu-latest"
-    permissions:
-      contents: "read"
-      id-token: "write"
-    needs: [build, update-manifest-dev]
-    steps:
-      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
-      - name: "Deploy to dev"
-        uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
-        env:
-          CLUSTER: dev-gcp
-          RESOURCE: microfrontends/dialogmote/nais/dev-gcp/nais.yaml
-          VAR: image=${{ needs.build.outputs.image }},version=${{ github.sha }}
-
-  # deploy-prod:
-  #   if: github.ref == 'refs/heads/main'
-  #   runs-on: "ubuntu-latest"
-  #   permissions:
-  #     contents: "read"
-  #     id-token: "write"
-  #   needs: [build, update-manifest-prod]
-
-  #   steps:
-  #     - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
-  #     - name: "Deploy to prod"
-  #       uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
-  #       env:
-  #         CLUSTER: prod-gcp
-  #         RESOURCE: microfrontends/dialogmote/nais/prod-gcp/nais.yaml
-  #         VAR: image=${{ needs.build.outputs.image }},version=${{ github.sha }}

--- a/.github/workflows/deploy-dialogmote.yaml
+++ b/.github/workflows/deploy-dialogmote.yaml
@@ -18,9 +18,8 @@ jobs:
       build_script: "build:dialogmote-microfrontend"
       dockerfile: "./microfrontends/dialogmote/Dockerfile"
       cdn_source: "./microfrontends/dialogmote/dist/client/_astro"
-      cdn_destination: "dialogmote-microfrontend"
       manifest_id: "syfo-dialog"
-      app_name: "dialogmote-microfrontend"
+      application_name: "dialogmote-microfrontend"
       dev_manifest_url: "http://dialogmote-microfrontend.min-side"
       dev_resource: "microfrontends/dialogmote/nais/dev-gcp/nais.yaml"
       enable_prod: false

--- a/.github/workflows/deploy-dialogmote.yaml
+++ b/.github/workflows/deploy-dialogmote.yaml
@@ -6,6 +6,7 @@ on:
       - "main"
     paths:
       - "microfrontends/dialogmote/**"
+      - "packages/shared/**"
       - "pnpm-lock.yaml"
       - "package.json"
   workflow_dispatch:

--- a/.github/workflows/deploy-dialogmote.yaml
+++ b/.github/workflows/deploy-dialogmote.yaml
@@ -22,9 +22,7 @@ jobs:
       manifest_id: "syfo-dialog"
       app_name: "dialogmote-microfrontend"
       dev_manifest_url: "http://dialogmote-microfrontend.min-side"
-      dev_namespace: "team-esyfo"
-      fallback: "fallback"
+      namespace: "team-esyfo"
       dev_resource: "microfrontends/dialogmote/nais/dev-gcp/nais.yaml"
-      commit_message: ${{ github.event.head_commit.message }}
       enable_prod: false
     secrets: inherit

--- a/.github/workflows/deploy-dialogmote.yaml
+++ b/.github/workflows/deploy-dialogmote.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - "main"
-      - "deploy-dialogmote"
     paths:
       - "microfrontends/dialogmote/**"
       - "pnpm-lock.yaml"
       - "package.json"
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-dialogmote.yaml
+++ b/.github/workflows/deploy-dialogmote.yaml
@@ -22,7 +22,6 @@ jobs:
       manifest_id: "syfo-dialog"
       app_name: "dialogmote-microfrontend"
       dev_manifest_url: "http://dialogmote-microfrontend.min-side"
-      namespace: "team-esyfo"
       dev_resource: "microfrontends/dialogmote/nais/dev-gcp/nais.yaml"
       enable_prod: false
     secrets: inherit

--- a/.github/workflows/deploy-meroppfolging.yaml
+++ b/.github/workflows/deploy-meroppfolging.yaml
@@ -18,9 +18,8 @@ jobs:
       build_script: "build:meroppfolging-microfrontend"
       dockerfile: "./microfrontends/meroppfolging/Dockerfile"
       cdn_source: "./microfrontends/meroppfolging/dist/client/_astro"
-      cdn_destination: "meroppfolging-microfrontend"
       manifest_id: "syfo-meroppfolging"
-      app_name: "meroppfolging-microfrontend"
+      application_name: "meroppfolging-microfrontend"
       dev_manifest_url: "http://meroppfolging-microfrontend.min-side"
       dev_resource: "microfrontends/meroppfolging/nais/dev-gcp/nais.yaml"
       enable_prod: false

--- a/.github/workflows/deploy-meroppfolging.yaml
+++ b/.github/workflows/deploy-meroppfolging.yaml
@@ -1,4 +1,5 @@
-name: "Deploy dev&prod"
+name: Deploy meroppfolging
+
 on:
   push:
     branches:
@@ -10,112 +11,20 @@ on:
       - "package.json"
 
 jobs:
-  build:
-    name: "build"
-    runs-on: "ubuntu-latest"
-
-    permissions:
-      contents: "read"
-      id-token: "write"
-      packages: "write"
-
-    steps:
-      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
-      - uses: "pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320" # v5.0.0
-      - uses: "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f" # v6.3.0
-        with:
-          node-version: 24
-          registry-url: "https://npm.pkg.github.com"
-          cache: "pnpm"
-
-      - name: "Install dependencies"
-        run: "pnpm install --frozen-lockfile"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
-
-      - name: "Run tests"
-        run: "pnpm test"
-
-      - name: "Build application"
-        run: "pnpm run build:meroppfolging-microfrontend"
-
-      - name: "Upload to cdn"
-        uses: "nais/deploy/actions/cdn-upload/v2@437e4adfe270e3f1c98fd0eed7f86ecf0e0873db" # master
-        with:
-          team: team-esyfo # Change this to your team name
-          source: ./microfrontends/meroppfolging/dist/client/_astro
-          destination: "meroppfolging-microfrontend" # Change this to your application name
-
-      - name: "Build and push"
-        uses: "nais/docker-build-push@45d352fb62fb52ccb5ff6cba22c047fa02b35321" # v0
-        id: docker-build-push
-        with:
-          team: team-esyfo # Change this to your team name
-          dockerfile: ./microfrontends/meroppfolging/Dockerfile
-
-    outputs:
-      image: ${{ steps.docker-build-push.outputs.image }}
-
-  update-manifest-dev:
-    permissions:
-      contents: "read"
-      id-token: "write"
-    uses: "navikt/tms-deploy/.github/workflows/oppdater-mikrofrontend-manifest-v3.yaml@67dc876fb9e1a0b115e47a36fd46a1c7b0064d4c" # main
-    needs: build
+  deploy:
+    uses: ./.github/workflows/deploy-microfrontend-reusable.yml
     with:
-      id: "syfo-meroppfolging" # Change this to your microfrontend id.
-      url: "http://meroppfolging-microfrontend.min-side" # Change the url to contain your application name. Example: http://my-app.namespace
-      appname: "meroppfolging-microfrontend" # Change this to your application name
-      namespace: "team-esyfo" # Change this to your namespace
-      cluster: dev-gcp
-      commitmsg: ${{ github.event.head_commit.message}}
-      fallback: "fallback" # Should containt the path to the fallback page after src/pages/[locale]/... Only needs to be changed if you move the fallback in the pages structure
-      ssr: true
+      microfrontend_name: "meroppfolging"
+      build_script: "build:meroppfolging-microfrontend"
+      dockerfile: "./microfrontends/meroppfolging/Dockerfile"
+      cdn_source: "./microfrontends/meroppfolging/dist/client/_astro"
+      cdn_destination: "meroppfolging-microfrontend"
+      manifest_id: "syfo-meroppfolging"
+      app_name: "meroppfolging-microfrontend"
+      dev_manifest_url: "http://meroppfolging-microfrontend.min-side"
+      dev_namespace: "team-esyfo"
+      fallback: "fallback"
+      dev_resource: "microfrontends/meroppfolging/nais/dev-gcp/nais.yaml"
+      commit_message: ${{ github.event.head_commit.message }}
+      enable_prod: false
     secrets: inherit
-
-  # update-manifest-prod:
-  #   if: github.ref == 'refs/heads/main'
-  #   uses: "navikt/tms-deploy/.github/workflows/oppdater-mikrofrontend-manifest-v3.yaml@67dc876fb9e1a0b115e47a36fd46a1c7b0064d4c" # main
-  #   needs: build
-  #   with:
-  #     id: "syfo-meroppfolging"
-  #     url: "http://meroppfolging-microfrontend.min-side"
-  #     appname: "meroppfolging-microfrontend"
-  #     namespace: "min-side"
-  #     cluster: prod-gcp
-  #     commitmsg: ${{ github.event.head_commit.message}}
-  #     fallback: "fallback" # Should containt the path to the fallback page after src/pages/[locale]/...
-  #     ssr: true
-  #   secrets: inherit
-
-  deploy-dev:
-    runs-on: "ubuntu-latest"
-    permissions:
-      contents: "read"
-      id-token: "write"
-    needs: [build, update-manifest-dev]
-    steps:
-      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
-      - name: "Deploy to dev"
-        uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
-        env:
-          CLUSTER: dev-gcp
-          RESOURCE: microfrontends/meroppfolging/nais/dev-gcp/nais.yaml
-          VAR: image=${{ needs.build.outputs.image }},version=${{ github.sha }}
-
-  # deploy-prod:
-  #   if: github.ref == 'refs/heads/main'
-  #   runs-on: "ubuntu-latest"
-  #   permissions:
-  #     contents: "read"
-  #     id-token: "write"
-  #   needs: [build, update-manifest-prod]
-
-  #   steps:
-  #     - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
-  #     - name: "Deploy to prod"
-  #       uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
-  #       env:
-  #         CLUSTER: prod-gcp
-  #         RESOURCE: microfrontends/meroppfolging/nais/prod-gcp/nais.yaml
-  #         VAR: image=${{ needs.build.outputs.image }},version=${{ github.sha }}

--- a/.github/workflows/deploy-meroppfolging.yaml
+++ b/.github/workflows/deploy-meroppfolging.yaml
@@ -22,7 +22,6 @@ jobs:
       manifest_id: "syfo-meroppfolging"
       app_name: "meroppfolging-microfrontend"
       dev_manifest_url: "http://meroppfolging-microfrontend.min-side"
-      namespace: "team-esyfo"
       dev_resource: "microfrontends/meroppfolging/nais/dev-gcp/nais.yaml"
       enable_prod: false
     secrets: inherit

--- a/.github/workflows/deploy-meroppfolging.yaml
+++ b/.github/workflows/deploy-meroppfolging.yaml
@@ -22,9 +22,7 @@ jobs:
       manifest_id: "syfo-meroppfolging"
       app_name: "meroppfolging-microfrontend"
       dev_manifest_url: "http://meroppfolging-microfrontend.min-side"
-      dev_namespace: "team-esyfo"
-      fallback: "fallback"
+      namespace: "team-esyfo"
       dev_resource: "microfrontends/meroppfolging/nais/dev-gcp/nais.yaml"
-      commit_message: ${{ github.event.head_commit.message }}
       enable_prod: false
     secrets: inherit

--- a/.github/workflows/deploy-meroppfolging.yaml
+++ b/.github/workflows/deploy-meroppfolging.yaml
@@ -6,6 +6,7 @@ on:
       - "main"
     paths:
       - "microfrontends/meroppfolging/**"
+      - "packages/shared/**"
       - "pnpm-lock.yaml"
       - "package.json"
   workflow_dispatch:

--- a/.github/workflows/deploy-meroppfolging.yaml
+++ b/.github/workflows/deploy-meroppfolging.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - "main"
-      - "deploy-meroppfolging"
     paths:
       - "microfrontends/meroppfolging/**"
       - "pnpm-lock.yaml"
       - "package.json"
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -35,20 +35,12 @@ on:
         description: Dev URL registered in the manifest
         required: true
         type: string
-      dev_namespace:
-        description: Namespace used when updating the dev manifest
-        required: true
-        type: string
-      fallback:
-        description: Fallback route path relative to locale pages
+      namespace:
+        description: Namespace used when updating manifests
         required: true
         type: string
       dev_resource:
         description: NAIS resource used for dev deploy
-        required: true
-        type: string
-      commit_message:
-        description: Head commit message used for manifest updates
         required: true
         type: string
       enable_prod:
@@ -58,11 +50,6 @@ on:
         type: boolean
       prod_manifest_url:
         description: Prod URL registered in the manifest
-        required: false
-        default: ""
-        type: string
-      prod_namespace:
-        description: Namespace used when updating the prod manifest
         required: false
         default: ""
         type: string
@@ -137,10 +124,10 @@ jobs:
       id: ${{ inputs.manifest_id }}
       url: ${{ inputs.dev_manifest_url }}
       appname: ${{ inputs.app_name }}
-      namespace: ${{ inputs.dev_namespace }}
+      namespace: ${{ inputs.namespace }}
       cluster: "dev-gcp"
-      commitmsg: ${{ inputs.commit_message }}
-      fallback: ${{ inputs.fallback }}
+      commitmsg: ${{ github.event.head_commit.message }}
+      fallback: "fallback"
       ssr: true
     secrets: inherit
 
@@ -162,7 +149,7 @@ jobs:
 
   update-manifest-prod:
     name: Update manifest prod
-    if: github.ref == 'refs/heads/main' && inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_namespace != '' && inputs.prod_resource != '' && inputs.prod_environment != ''
+    if: github.ref == 'refs/heads/main' && inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_resource != '' && inputs.prod_environment != ''
     permissions:
       contents: "read"
       id-token: "write"
@@ -172,16 +159,16 @@ jobs:
       id: ${{ inputs.manifest_id }}
       url: ${{ inputs.prod_manifest_url }}
       appname: ${{ inputs.app_name }}
-      namespace: ${{ inputs.prod_namespace }}
+      namespace: ${{ inputs.namespace }}
       cluster: "prod-gcp"
-      commitmsg: ${{ inputs.commit_message }}
-      fallback: ${{ inputs.fallback }}
+      commitmsg: ${{ github.event.head_commit.message }}
+      fallback: "fallback"
       ssr: true
     secrets: inherit
 
   deploy-prod:
     name: Deploy to prod
-    if: github.ref == 'refs/heads/main' && inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_namespace != '' && inputs.prod_resource != '' && inputs.prod_environment != ''
+    if: github.ref == 'refs/heads/main' && inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_resource != '' && inputs.prod_environment != ''
     runs-on: "ubuntu-latest"
     permissions:
       contents: "read"

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -120,7 +120,7 @@ jobs:
       id: ${{ inputs.manifest_id }}
       url: ${{ inputs.dev_manifest_url }}
       appname: ${{ inputs.app_name }}
-      namespace: ${{ env.TEAM }}
+      namespace: "team-esyfo"
       cluster: "dev-gcp"
       commitmsg: ${{ github.event.head_commit.message }}
       fallback: "fallback"
@@ -155,7 +155,7 @@ jobs:
       id: ${{ inputs.manifest_id }}
       url: ${{ inputs.prod_manifest_url }}
       appname: ${{ inputs.app_name }}
-      namespace: ${{ env.TEAM }}
+      namespace: "team-esyfo"
       cluster: "prod-gcp"
       commitmsg: ${{ github.event.head_commit.message }}
       fallback: "fallback"

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -65,7 +65,6 @@ on:
 
 env:
   NODE_VERSION: "24"
-  TEAM: "team-esyfo"
 
 jobs:
   build:
@@ -95,7 +94,7 @@ jobs:
       - name: Upload to cdn
         uses: "nais/deploy/actions/cdn-upload/v2@437e4adfe270e3f1c98fd0eed7f86ecf0e0873db" # master
         with:
-          team: ${{ env.TEAM }}
+          team: "team-esyfo"
           source: ${{ inputs.cdn_source }}
           destination: ${{ inputs.cdn_destination }}
 
@@ -103,7 +102,7 @@ jobs:
         uses: "nais/docker-build-push@45d352fb62fb52ccb5ff6cba22c047fa02b35321" # v0
         id: docker-build-push
         with:
-          team: ${{ env.TEAM }}
+          team: "team-esyfo"
           dockerfile: ${{ inputs.dockerfile }}
 
     outputs:

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -51,7 +51,7 @@ on:
         default: ""
         type: string
     secrets:
-      npm_auth_token:
+      READER_TOKEN:
         required: true
 
 env:
@@ -77,7 +77,7 @@ jobs:
       - name: Install dependencies
         run: "pnpm install --frozen-lockfile"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_auth_token }}
+          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
       - name: Build application
         run: "pnpm run ${{ inputs.build_script }}"

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -1,0 +1,202 @@
+name: Reusable microfrontend deploy
+
+on:
+  workflow_call:
+    inputs:
+      microfrontend_name:
+        description: Human-readable microfrontend name for job labels
+        required: true
+        type: string
+      build_script:
+        description: Root package.json build script for the microfrontend
+        required: true
+        type: string
+      dockerfile:
+        description: Path to the microfrontend Dockerfile
+        required: true
+        type: string
+      cdn_source:
+        description: Built client asset directory to upload
+        required: true
+        type: string
+      cdn_destination:
+        description: CDN destination directory
+        required: true
+        type: string
+      manifest_id:
+        description: TMS microfrontend id
+        required: true
+        type: string
+      app_name:
+        description: Application name registered in the manifest
+        required: true
+        type: string
+      dev_manifest_url:
+        description: Dev URL registered in the manifest
+        required: true
+        type: string
+      dev_namespace:
+        description: Namespace used when updating the dev manifest
+        required: true
+        type: string
+      fallback:
+        description: Fallback route path relative to locale pages
+        required: true
+        type: string
+      dev_resource:
+        description: NAIS resource used for dev deploy
+        required: true
+        type: string
+      commit_message:
+        description: Head commit message used for manifest updates
+        required: true
+        type: string
+      enable_prod:
+        description: Enables prod manifest update and deploy when prod inputs are also set
+        required: false
+        default: false
+        type: boolean
+      prod_manifest_url:
+        description: Prod URL registered in the manifest
+        required: false
+        default: ""
+        type: string
+      prod_namespace:
+        description: Namespace used when updating the prod manifest
+        required: false
+        default: ""
+        type: string
+      prod_resource:
+        description: NAIS resource used for prod deploy
+        required: false
+        default: ""
+        type: string
+      prod_environment:
+        description: GitHub environment name used to gate prod deploy
+        required: false
+        default: ""
+        type: string
+    secrets:
+      npm_auth_token:
+        required: true
+
+env:
+  NODE_VERSION: "24"
+  TEAM: "team-esyfo"
+
+jobs:
+  build:
+    name: Build ${{ inputs.microfrontend_name }}
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: "read"
+      id-token: "write"
+      packages: "write"
+    steps:
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
+      - uses: "pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320" # v5.0.0
+      - uses: "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f" # v6.3.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://npm.pkg.github.com"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: "pnpm install --frozen-lockfile"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_auth_token }}
+
+      - name: Run tests
+        run: "pnpm test"
+
+      - name: Build application
+        run: "pnpm run ${{ inputs.build_script }}"
+
+      - name: Upload to cdn
+        uses: "nais/deploy/actions/cdn-upload/v2@437e4adfe270e3f1c98fd0eed7f86ecf0e0873db" # master
+        with:
+          team: ${{ env.TEAM }}
+          source: ${{ inputs.cdn_source }}
+          destination: ${{ inputs.cdn_destination }}
+
+      - name: Build and push
+        uses: "nais/docker-build-push@45d352fb62fb52ccb5ff6cba22c047fa02b35321" # v0
+        id: docker-build-push
+        with:
+          team: ${{ env.TEAM }}
+          dockerfile: ${{ inputs.dockerfile }}
+
+    outputs:
+      image: ${{ steps.docker-build-push.outputs.image }}
+
+  update-manifest-dev:
+    name: Update manifest dev
+    permissions:
+      contents: "read"
+      id-token: "write"
+    uses: "navikt/tms-deploy/.github/workflows/oppdater-mikrofrontend-manifest-v3.yaml@67dc876fb9e1a0b115e47a36fd46a1c7b0064d4c" # main
+    needs: build
+    with:
+      id: ${{ inputs.manifest_id }}
+      url: ${{ inputs.dev_manifest_url }}
+      appname: ${{ inputs.app_name }}
+      namespace: ${{ inputs.dev_namespace }}
+      cluster: "dev-gcp"
+      commitmsg: ${{ inputs.commit_message }}
+      fallback: ${{ inputs.fallback }}
+      ssr: true
+    secrets: inherit
+
+  deploy-dev:
+    name: Deploy to dev
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: "read"
+      id-token: "write"
+    needs: [build, update-manifest-dev]
+    steps:
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
+      - name: Deploy to dev
+        uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
+        env:
+          CLUSTER: "dev-gcp"
+          RESOURCE: ${{ inputs.dev_resource }}
+          VAR: image=${{ needs.build.outputs.image }},version=${{ github.sha }}
+
+  update-manifest-prod:
+    name: Update manifest prod
+    if: inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_namespace != '' && inputs.prod_resource != '' && inputs.prod_environment != ''
+    permissions:
+      contents: "read"
+      id-token: "write"
+    uses: "navikt/tms-deploy/.github/workflows/oppdater-mikrofrontend-manifest-v3.yaml@67dc876fb9e1a0b115e47a36fd46a1c7b0064d4c" # main
+    needs: build
+    with:
+      id: ${{ inputs.manifest_id }}
+      url: ${{ inputs.prod_manifest_url }}
+      appname: ${{ inputs.app_name }}
+      namespace: ${{ inputs.prod_namespace }}
+      cluster: "prod-gcp"
+      commitmsg: ${{ inputs.commit_message }}
+      fallback: ${{ inputs.fallback }}
+      ssr: true
+    secrets: inherit
+
+  deploy-prod:
+    name: Deploy to prod
+    if: inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_namespace != '' && inputs.prod_resource != '' && inputs.prod_environment != ''
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: "read"
+      id-token: "write"
+    needs: [build, update-manifest-prod]
+    environment:
+      name: ${{ inputs.prod_environment }}
+    steps:
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
+      - name: Deploy to prod
+        uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
+        env:
+          CLUSTER: "prod-gcp"
+          RESOURCE: ${{ inputs.prod_resource }}
+          VAR: image=${{ needs.build.outputs.image }},version=${{ github.sha }}

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -35,10 +35,6 @@ on:
         description: Dev URL registered in the manifest
         required: true
         type: string
-      namespace:
-        description: Namespace used when updating manifests
-        required: true
-        type: string
       dev_resource:
         description: NAIS resource used for dev deploy
         required: true
@@ -124,7 +120,7 @@ jobs:
       id: ${{ inputs.manifest_id }}
       url: ${{ inputs.dev_manifest_url }}
       appname: ${{ inputs.app_name }}
-      namespace: ${{ inputs.namespace }}
+      namespace: ${{ env.TEAM }}
       cluster: "dev-gcp"
       commitmsg: ${{ github.event.head_commit.message }}
       fallback: "fallback"
@@ -159,7 +155,7 @@ jobs:
       id: ${{ inputs.manifest_id }}
       url: ${{ inputs.prod_manifest_url }}
       appname: ${{ inputs.app_name }}
-      namespace: ${{ inputs.namespace }}
+      namespace: ${{ env.TEAM }}
       cluster: "prod-gcp"
       commitmsg: ${{ github.event.head_commit.message }}
       fallback: "fallback"

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -50,11 +50,6 @@ on:
         required: false
         default: ""
         type: string
-      prod_environment:
-        description: GitHub environment name used to gate prod deploy
-        required: false
-        default: ""
-        type: string
     secrets:
       npm_auth_token:
         required: true
@@ -140,7 +135,7 @@ jobs:
 
   update-manifest-prod:
     name: Update manifest prod
-    if: github.ref == 'refs/heads/main' && inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_resource != '' && inputs.prod_environment != ''
+    if: github.ref == 'refs/heads/main' && inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_resource != ''
     permissions:
       contents: "read"
       id-token: "write"
@@ -159,14 +154,12 @@ jobs:
 
   deploy-prod:
     name: Deploy to prod
-    if: github.ref == 'refs/heads/main' && inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_resource != '' && inputs.prod_environment != ''
+    if: github.ref == 'refs/heads/main' && inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_resource != ''
     runs-on: "ubuntu-latest"
     permissions:
       contents: "read"
       id-token: "write"
     needs: [build, update-manifest-prod]
-    environment:
-      name: ${{ inputs.prod_environment }}
     steps:
       - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
       - name: Deploy to prod

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -106,9 +106,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_auth_token }}
 
-      - name: Run tests
-        run: "pnpm test"
-
       - name: Build application
         run: "pnpm run ${{ inputs.build_script }}"
 
@@ -165,7 +162,7 @@ jobs:
 
   update-manifest-prod:
     name: Update manifest prod
-    if: inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_namespace != '' && inputs.prod_resource != '' && inputs.prod_environment != ''
+    if: github.ref == 'refs/heads/main' && inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_namespace != '' && inputs.prod_resource != '' && inputs.prod_environment != ''
     permissions:
       contents: "read"
       id-token: "write"
@@ -184,7 +181,7 @@ jobs:
 
   deploy-prod:
     name: Deploy to prod
-    if: inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_namespace != '' && inputs.prod_resource != '' && inputs.prod_environment != ''
+    if: github.ref == 'refs/heads/main' && inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_namespace != '' && inputs.prod_resource != '' && inputs.prod_environment != ''
     runs-on: "ubuntu-latest"
     permissions:
       contents: "read"

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -19,16 +19,12 @@ on:
         description: Built client asset directory to upload
         required: true
         type: string
-      cdn_destination:
-        description: CDN destination directory
-        required: true
-        type: string
       manifest_id:
         description: TMS microfrontend id
         required: true
         type: string
-      app_name:
-        description: Application name registered in the manifest
+      application_name:
+        description: Application name reused for CDN destination and manifest registration
         required: true
         type: string
       dev_manifest_url:
@@ -96,7 +92,7 @@ jobs:
         with:
           team: "team-esyfo"
           source: ${{ inputs.cdn_source }}
-          destination: ${{ inputs.cdn_destination }}
+          destination: ${{ inputs.application_name }}
 
       - name: Build and push
         uses: "nais/docker-build-push@45d352fb62fb52ccb5ff6cba22c047fa02b35321" # v0
@@ -118,7 +114,7 @@ jobs:
     with:
       id: ${{ inputs.manifest_id }}
       url: ${{ inputs.dev_manifest_url }}
-      appname: ${{ inputs.app_name }}
+      appname: ${{ inputs.application_name }}
       namespace: "team-esyfo"
       cluster: "dev-gcp"
       commitmsg: ${{ github.event.head_commit.message }}
@@ -153,7 +149,7 @@ jobs:
     with:
       id: ${{ inputs.manifest_id }}
       url: ${{ inputs.prod_manifest_url }}
-      appname: ${{ inputs.app_name }}
+      appname: ${{ inputs.application_name }}
       namespace: "team-esyfo"
       cluster: "prod-gcp"
       commitmsg: ${{ github.event.head_commit.message }}

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -112,7 +112,7 @@ jobs:
       appname: ${{ inputs.application_name }}
       namespace: "team-esyfo"
       cluster: "dev-gcp"
-      commitmsg: ${{ github.event.head_commit.message }}
+      commitmsg: ${{ github.event.head_commit.message || format('Manual deploy from {0} ({1})', github.ref_name, github.sha) }}
       fallback: "fallback"
       ssr: true
     secrets: inherit
@@ -147,7 +147,7 @@ jobs:
       appname: ${{ inputs.application_name }}
       namespace: "team-esyfo"
       cluster: "prod-gcp"
-      commitmsg: ${{ github.event.head_commit.message }}
+      commitmsg: ${{ github.event.head_commit.message || format('Manual deploy from {0} ({1})', github.ref_name, github.sha) }}
       fallback: "fallback"
       ssr: true
     secrets: inherit

--- a/.github/workflows/deploy-motebehov.yaml
+++ b/.github/workflows/deploy-motebehov.yaml
@@ -18,9 +18,8 @@ jobs:
       build_script: "build:motebehov-microfrontend"
       dockerfile: "./microfrontends/motebehov/Dockerfile"
       cdn_source: "./microfrontends/motebehov/dist/client/_astro"
-      cdn_destination: "motebehov-microfrontend"
       manifest_id: "syfo-motebehov"
-      app_name: "motebehov-microfrontend"
+      application_name: "motebehov-microfrontend"
       dev_manifest_url: "http://motebehov-microfrontend.min-side"
       dev_resource: "microfrontends/motebehov/nais/dev-gcp/nais.yaml"
       enable_prod: false

--- a/.github/workflows/deploy-motebehov.yaml
+++ b/.github/workflows/deploy-motebehov.yaml
@@ -6,6 +6,7 @@ on:
       - "main"
     paths:
       - "microfrontends/motebehov/**"
+      - "packages/shared/**"
       - "pnpm-lock.yaml"
       - "package.json"
   workflow_dispatch:

--- a/.github/workflows/deploy-motebehov.yaml
+++ b/.github/workflows/deploy-motebehov.yaml
@@ -22,7 +22,6 @@ jobs:
       manifest_id: "syfo-motebehov"
       app_name: "motebehov-microfrontend"
       dev_manifest_url: "http://motebehov-microfrontend.min-side"
-      namespace: "team-esyfo"
       dev_resource: "microfrontends/motebehov/nais/dev-gcp/nais.yaml"
       enable_prod: false
     secrets: inherit

--- a/.github/workflows/deploy-motebehov.yaml
+++ b/.github/workflows/deploy-motebehov.yaml
@@ -22,9 +22,7 @@ jobs:
       manifest_id: "syfo-motebehov"
       app_name: "motebehov-microfrontend"
       dev_manifest_url: "http://motebehov-microfrontend.min-side"
-      dev_namespace: "team-esyfo"
-      fallback: "fallback"
+      namespace: "team-esyfo"
       dev_resource: "microfrontends/motebehov/nais/dev-gcp/nais.yaml"
-      commit_message: ${{ github.event.head_commit.message }}
       enable_prod: false
     secrets: inherit

--- a/.github/workflows/deploy-motebehov.yaml
+++ b/.github/workflows/deploy-motebehov.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - "main"
-      - "deploy-motebehov"
     paths:
       - "microfrontends/motebehov/**"
       - "pnpm-lock.yaml"
       - "package.json"
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-motebehov.yaml
+++ b/.github/workflows/deploy-motebehov.yaml
@@ -1,4 +1,5 @@
-name: "Deploy dev&prod"
+name: Deploy motebehov
+
 on:
   push:
     branches:
@@ -10,112 +11,20 @@ on:
       - "package.json"
 
 jobs:
-  build:
-    name: "build"
-    runs-on: "ubuntu-latest"
-
-    permissions:
-      contents: "read"
-      id-token: "write"
-      packages: "write"
-
-    steps:
-      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
-      - uses: "pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320" # v5.0.0
-      - uses: "actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f" # v6.3.0
-        with:
-          node-version: 24
-          registry-url: "https://npm.pkg.github.com"
-          cache: "pnpm"
-
-      - name: "Install dependencies"
-        run: "pnpm install --frozen-lockfile"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
-
-      - name: "Run tests"
-        run: "pnpm test"
-
-      - name: "Build application"
-        run: "pnpm run build:motebehov-microfrontend"
-
-      - name: "Upload to cdn"
-        uses: "nais/deploy/actions/cdn-upload/v2@437e4adfe270e3f1c98fd0eed7f86ecf0e0873db" # master
-        with:
-          team: team-esyfo # Change this to your team name
-          source: ./microfrontends/motebehov/dist/client/_astro
-          destination: "motebehov-microfrontend" # Change this to your application name
-
-      - name: "Build and push"
-        uses: "nais/docker-build-push@45d352fb62fb52ccb5ff6cba22c047fa02b35321" # v0
-        id: docker-build-push
-        with:
-          team: team-esyfo # Change this to your team name
-          dockerfile: ./microfrontends/motebehov/Dockerfile
-
-    outputs:
-      image: ${{ steps.docker-build-push.outputs.image }}
-
-  update-manifest-dev:
-    permissions:
-      contents: "read"
-      id-token: "write"
-    uses: "navikt/tms-deploy/.github/workflows/oppdater-mikrofrontend-manifest-v3.yaml@67dc876fb9e1a0b115e47a36fd46a1c7b0064d4c" # main
-    needs: build
+  deploy:
+    uses: ./.github/workflows/deploy-microfrontend-reusable.yml
     with:
-      id: "syfo-motebehov" # Change this to your microfrontend id.
-      url: "http://motebehov-microfrontend.min-side" # Change the url to contain your application name. Example: http://my-app.namespace
-      appname: "motebehov-microfrontend" # Change this to your application name
-      namespace: "team-esyfo" # Change this to your namespace
-      cluster: dev-gcp
-      commitmsg: ${{ github.event.head_commit.message}}
-      fallback: "fallback" # Should containt the path to the fallback page after src/pages/[locale]/... Only needs to be changed if you move the fallback in the pages structure
-      ssr: true
+      microfrontend_name: "motebehov"
+      build_script: "build:motebehov-microfrontend"
+      dockerfile: "./microfrontends/motebehov/Dockerfile"
+      cdn_source: "./microfrontends/motebehov/dist/client/_astro"
+      cdn_destination: "motebehov-microfrontend"
+      manifest_id: "syfo-motebehov"
+      app_name: "motebehov-microfrontend"
+      dev_manifest_url: "http://motebehov-microfrontend.min-side"
+      dev_namespace: "team-esyfo"
+      fallback: "fallback"
+      dev_resource: "microfrontends/motebehov/nais/dev-gcp/nais.yaml"
+      commit_message: ${{ github.event.head_commit.message }}
+      enable_prod: false
     secrets: inherit
-
-  # update-manifest-prod:
-  #   if: github.ref == 'refs/heads/main'
-  #   uses: "navikt/tms-deploy/.github/workflows/oppdater-mikrofrontend-manifest-v3.yaml@67dc876fb9e1a0b115e47a36fd46a1c7b0064d4c" # main
-  #   needs: build
-  #   with:
-  #     id: "syfo-dialog"
-  #     url: "http://tms-microfrontend-template-ssr.min-side"
-  #     appname: "tms-microfrontend-template-ssr"
-  #     namespace: "team-namespace"
-  #     cluster: prod-gcp
-  #     commitmsg: ${{ github.event.head_commit.message}}
-  #     fallback: "fallback" # Should containt the path to the fallback page after src/pages/[locale]/...
-  #     ssr: true
-  #   secrets: inherit
-
-  deploy-dev:
-    runs-on: "ubuntu-latest"
-    permissions:
-      contents: "read"
-      id-token: "write"
-    needs: [build, update-manifest-dev]
-    steps:
-      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
-      - name: "Deploy to dev"
-        uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
-        env:
-          CLUSTER: dev-gcp
-          RESOURCE: microfrontends/motebehov/nais/dev-gcp/nais.yaml
-          VAR: image=${{ needs.build.outputs.image }},version=${{ github.sha }}
-
-  # deploy-prod:
-  #   if: github.ref == 'refs/heads/main'
-  #   runs-on: "ubuntu-latest"
-  #   permissions:
-  #     contents: "read"
-  #     id-token: "write"
-  #   needs: [build, update-manifest-prod]
-
-  #   steps:
-  #     - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
-  #     - name: "Deploy to prod"
-  #       uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
-  #       env:
-  #         CLUSTER: prod-gcp
-  #         RESOURCE: microfrontends/dialogmote/nais/prod-gcp/nais.yaml
-  #         VAR: image=${{ needs.build.outputs.image }},version=${{ github.sha }}


### PR DESCRIPTION
## Beskrivelse

Refaktorer deploy-oppsettet for mikrofrontendene til ett gjenbrukbart workflow og tynne wrappers per app. Dette reduserer duplisering og gjør deploy-guardrails og trigger-logikk konsekvent på tvers av mikrofrontendene.

## Endringer

- `.github/workflows/deploy-microfrontend-reusable.yml`: nytt gjenbrukbart workflow for bygg, CDN-upload, manifest-oppdatering og deploy
- `.github/workflows/deploy-{dialogmote,aktivitetskrav,meroppfolging,motebehov}.yaml`: erstattet kopierte workflows med tynne wrappers
- Deploy-triggere for branch-testing er gjort manuelle via `workflow_dispatch`, mens `main` fortsatt deployer automatisk til dev
- `packages/shared/**` er lagt til i path-filtrene slik at delte kodeendringer utløser relevante deploys
- Prod-guardrails er forenklet til `main` + `enable_prod` + eksplisitte prod-inputs

## Issue

Relates to #101

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
