### PR TITLE
fix(actions): grant deploy wrapper permissions

### DIFF
--- a/.github/workflows/deploy-aktivitetskrav.yaml
+++ b/.github/workflows/deploy-aktivitetskrav.yaml
@@ -11,6 +11,11 @@ on:
       - "package.json"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 jobs:
   deploy:
     uses: ./.github/workflows/deploy-microfrontend-reusable.yml

--- a/.github/workflows/deploy-dialogmote.yaml
+++ b/.github/workflows/deploy-dialogmote.yaml
@@ -11,6 +11,11 @@ on:
       - "package.json"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 jobs:
   deploy:
     uses: ./.github/workflows/deploy-microfrontend-reusable.yml

--- a/.github/workflows/deploy-meroppfolging.yaml
+++ b/.github/workflows/deploy-meroppfolging.yaml
@@ -11,6 +11,11 @@ on:
       - "package.json"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 jobs:
   deploy:
     uses: ./.github/workflows/deploy-microfrontend-reusable.yml

--- a/.github/workflows/deploy-motebehov.yaml
+++ b/.github/workflows/deploy-motebehov.yaml
@@ -11,6 +11,11 @@ on:
       - "package.json"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 jobs:
   deploy:
     uses: ./.github/workflows/deploy-microfrontend-reusable.yml


### PR DESCRIPTION
## Beskrivelse

Legger til manglende top-level permissions i deploy-wrapperne slik at det gjenbrukbare deploy-workflowet kan be om de tilgangene det faktisk trenger. Uten dette feiler manuelle deploy-runs med permission-feil for `packages` og `id-token`.

## Endringer

- `.github/workflows/deploy-aktivitetskrav.yaml`: legger til eksplisitte workflow-permissions
- `.github/workflows/deploy-dialogmote.yaml`: legger til eksplisitte workflow-permissions
- `.github/workflows/deploy-meroppfolging.yaml`: legger til eksplisitte workflow-permissions
- `.github/workflows/deploy-motebehov.yaml`: legger til eksplisitte workflow-permissions

## Issue

Relates to #101

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
