### PR TITLE
fix(deploy): isolate microfrontend deploy images

### DIFF
--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -54,6 +54,10 @@ on:
       READER_TOKEN:
         required: true
 
+concurrency:
+  group: deploy-${{ inputs.microfrontend_name }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 env:
   NODE_VERSION: "24"
 

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -95,6 +95,7 @@ jobs:
         with:
           team: "team-esyfo"
           dockerfile: ${{ inputs.dockerfile }}
+          image_suffix: ${{ inputs.microfrontend_name }}
 
     outputs:
       image: ${{ steps.docker-build-push.outputs.image }}


### PR DESCRIPTION
## Beskrivelse

Retter en monorepo-feil i den gjenbrukbare deploy-workflowen der flere microfrontend-deployer fra samme commit kunne publisere samme Docker-image og dermed overskrive hverandre. PR-en gjør image-navnet unikt per microfrontend og serialiserer deployer per microfrontend/branch for å unngå overlappende deploy-lop.

## Endringer

- `.github/workflows/deploy-microfrontend-reusable.yml`: setter `image_suffix: ${{ inputs.microfrontend_name }}` slik at hvert microfrontend får eget image-navn i registry
- `.github/workflows/deploy-microfrontend-reusable.yml`: legger til `concurrency` med `deploy-${{ inputs.microfrontend_name }}-${{ github.ref_name }}` for å unngå samtidige deployer av samme microfrontend på samme ref

## Issue

Ingen egen issue - retter deploy-kollisjon oppdaget etter innføring av gjenbrukbar deploy-workflow.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
