### PR TITLE
fix(nais): align backend host configuration

### DIFF
--- a/microfrontends/aktivitetskrav/astro.config.mjs
+++ b/microfrontends/aktivitetskrav/astro.config.mjs
@@ -39,10 +39,10 @@ export default defineConfig({
   }),
   env: {
     schema: {
-      AKTIVITETSKRAV_API_URL: envField.string({
+      AKTIVITETSKRAV_BACKEND_HOST: envField.string({
         context: "server",
         access: "secret",
-        default: "http://aktivitetskrav-api/api/aktivitetsplikt",
+        default: "http://aktivitetskrav-backend",
       }),
       AKTIVITETSKRAV_CLIENT_ID: envField.string({
         context: "server",

--- a/microfrontends/aktivitetskrav/nais/dev-gcp/nais.yaml
+++ b/microfrontends/aktivitetskrav/nais/dev-gcp/nais.yaml
@@ -31,7 +31,6 @@ spec:
     outbound:
       rules:
         - application: aktivitetskrav-backend
-          namespace: team-esyfo
   resources:
     limits:
       memory: 768Mi

--- a/microfrontends/aktivitetskrav/nais/dev-gcp/nais.yaml
+++ b/microfrontends/aktivitetskrav/nais/dev-gcp/nais.yaml
@@ -39,7 +39,9 @@ spec:
       cpu: "20m"
       memory: 128Mi
   env:
-    - name: AKTIVITETSKRAV_API_URL
-      value: "http://aktivitetskrav-backend.team-esyfo/api/v1/aktivitetsplikt"
+    - name: AKTIVITETSKRAV_BACKEND_HOST
+      value: "http://aktivitetskrav-backend"
     - name: AKTIVITETSKRAV_CLIENT_ID
       value: "dev-gcp:team-esyfo:aktivitetskrav-backend"
+    - name: AKTIVITETSKRAV_URL
+      value: "https://www.ekstern.dev.nav.no/syk/aktivitetskrav"

--- a/microfrontends/aktivitetskrav/nais/prod-gcp/nais.yaml
+++ b/microfrontends/aktivitetskrav/nais/prod-gcp/nais.yaml
@@ -31,7 +31,6 @@ spec:
     outbound:
       rules:
         - application: aktivitetskrav-backend
-          namespace: team-esyfo
   resources:
     limits:
       memory: 768Mi

--- a/microfrontends/aktivitetskrav/nais/prod-gcp/nais.yaml
+++ b/microfrontends/aktivitetskrav/nais/prod-gcp/nais.yaml
@@ -1,10 +1,10 @@
 apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
-  name: aktivitetskrav-microfrontend # Change this to your application name
-  namespace: team-esyfo # Change this to your namespace
+  name: aktivitetskrav-microfrontend
+  namespace: team-esyfo
   labels:
-    team: team-esyfo # Change this to your team name
+    team: team-esyfo
 spec:
   observability:
     autoInstrumentation:
@@ -28,12 +28,20 @@ spec:
       rules:
         - application: tms-min-side
           namespace: min-side
+    outbound:
+      rules:
+        - application: aktivitetskrav-backend
+          namespace: team-esyfo
   resources:
     limits:
       memory: 768Mi
     requests:
       cpu: "20m"
       memory: 128Mi
-  env: # Add your environment variables here
-    - name: EXAMPLE_API_URL
-      value: "https://example.dev.nav.no/api"
+  env:
+    - name: AKTIVITETSKRAV_BACKEND_HOST
+      value: "http://aktivitetskrav-backend"
+    - name: AKTIVITETSKRAV_CLIENT_ID
+      value: "prod-gcp:team-esyfo:aktivitetskrav-backend"
+    - name: AKTIVITETSKRAV_URL
+      value: "https://www.nav.no/syk/aktivitetskrav"

--- a/microfrontends/aktivitetskrav/src/infrastructure/fetch.ts
+++ b/microfrontends/aktivitetskrav/src/infrastructure/fetch.ts
@@ -8,9 +8,8 @@ import { vurderingSchema } from "@schema/vurderingSchema";
 import type { AktivitetskravVurdering } from "@schema/vurderingSchema.ts";
 import { mockData } from "mock/data";
 
-const aktivitetskravBackendPath = "/api/v1/aktivitetsplikt";
 const aktivitetskravApiUrl = new URL(
-  aktivitetskravBackendPath,
+  "/api/v1/aktivitetsplikt",
   AKTIVITETSKRAV_BACKEND_HOST,
 ).toString();
 

--- a/microfrontends/aktivitetskrav/src/infrastructure/fetch.ts
+++ b/microfrontends/aktivitetskrav/src/infrastructure/fetch.ts
@@ -1,5 +1,5 @@
 import {
-  AKTIVITETSKRAV_API_URL,
+  AKTIVITETSKRAV_BACKEND_HOST,
   AKTIVITETSKRAV_CLIENT_ID,
 } from "astro:env/server";
 import { isLocal } from "@esyfo/shared/environment";
@@ -8,13 +8,19 @@ import { vurderingSchema } from "@schema/vurderingSchema";
 import type { AktivitetskravVurdering } from "@schema/vurderingSchema.ts";
 import { mockData } from "mock/data";
 
+const aktivitetskravBackendPath = "/api/v1/aktivitetsplikt";
+const aktivitetskravApiUrl = new URL(
+  aktivitetskravBackendPath,
+  AKTIVITETSKRAV_BACKEND_HOST,
+).toString();
+
 const realFetchVurdering = async (
   token: string,
 ): Promise<AktivitetskravVurdering> => {
   return fetchFromBackend({
     token,
     clientId: AKTIVITETSKRAV_CLIENT_ID,
-    apiUrl: AKTIVITETSKRAV_API_URL,
+    apiUrl: aktivitetskravApiUrl,
     apiName: "aktivitetskrav",
     schema: vurderingSchema,
   });

--- a/microfrontends/aktivitetskrav/vitest.setup.ts
+++ b/microfrontends/aktivitetskrav/vitest.setup.ts
@@ -9,6 +9,6 @@ vi.mock("@navikt/pino-logger", () => ({
 }));
 
 vi.mock("astro:env/server", () => ({
-  AKTIVITETSKRAV_API_URL: "http://aktivitetskrav-api/api/aktivitetsplikt",
+  AKTIVITETSKRAV_BACKEND_HOST: "http://aktivitetskrav-backend",
   AKTIVITETSKRAV_CLIENT_ID: "local:teamsykefravr:aktivitetskrav-api",
 }));

--- a/microfrontends/dialogmote/astro.config.mjs
+++ b/microfrontends/dialogmote/astro.config.mjs
@@ -39,10 +39,10 @@ export default defineConfig({
   }),
   env: {
     schema: {
-      ISDIALOGMOTE_API_URL: envField.string({
+      ISDIALOGMOTE_BACKEND_HOST: envField.string({
         context: "server",
         access: "secret",
-        default: "http://localhost:3000/api/dialogmote",
+        default: "http://localhost:3000",
       }),
       ISDIALOGMOTE_CLIENT_ID: envField.string({
         context: "server",

--- a/microfrontends/dialogmote/nais/dev-gcp/nais.yaml
+++ b/microfrontends/dialogmote/nais/dev-gcp/nais.yaml
@@ -39,8 +39,8 @@ spec:
       cpu: "20m"
       memory: 128Mi
   env: # Add your environment variables here
-    - name: ISDIALOGMOTE_API_URL
-      value: "http://isdialogmote.teamsykefravr/api/v2/arbeidstaker/brev"
+    - name: ISDIALOGMOTE_BACKEND_HOST
+      value: "http://isdialogmote.teamsykefravr"
     - name: ISDIALOGMOTE_CLIENT_ID
       value: dev-gcp:teamsykefravr:isdialogmote
     - name: DIALOGMOTE_URL

--- a/microfrontends/dialogmote/nais/prod-gcp/nais.yaml
+++ b/microfrontends/dialogmote/nais/prod-gcp/nais.yaml
@@ -39,8 +39,8 @@ spec:
       cpu: "20m"
       memory: 128Mi
   env: # Add your environment variables here
-    - name: ISDIALOGMOTE_API_URL
-      value: "http://isdialogmote.teamsykefravr/api/v2/arbeidstaker/brev"
+    - name: ISDIALOGMOTE_BACKEND_HOST
+      value: "http://isdialogmote.teamsykefravr"
     - name: ISDIALOGMOTE_CLIENT_ID
       value: prod-gcp:teamsykefravr:isdialogmote
     - name: DIALOGMOTE_URL

--- a/microfrontends/dialogmote/src/infrastructure/fetch.ts
+++ b/microfrontends/dialogmote/src/infrastructure/fetch.ts
@@ -8,9 +8,8 @@ import { brevSchema } from "@schema/brevSchema";
 import type { BrevDto } from "@schema/brevSchema.ts";
 import { mockData } from "mock/data";
 
-const dialogmoteBrevPath = "/api/v2/arbeidstaker/brev";
 const dialogmoteApiUrl = new URL(
-  dialogmoteBrevPath,
+  "/api/v2/arbeidstaker/brev",
   ISDIALOGMOTE_BACKEND_HOST,
 ).toString();
 

--- a/microfrontends/dialogmote/src/infrastructure/fetch.ts
+++ b/microfrontends/dialogmote/src/infrastructure/fetch.ts
@@ -1,15 +1,24 @@
-import { ISDIALOGMOTE_API_URL, ISDIALOGMOTE_CLIENT_ID } from "astro:env/server";
+import {
+  ISDIALOGMOTE_BACKEND_HOST,
+  ISDIALOGMOTE_CLIENT_ID,
+} from "astro:env/server";
 import { isLocal } from "@esyfo/shared/environment";
 import { fetchFromBackend } from "@esyfo/shared/fetch";
 import { brevSchema } from "@schema/brevSchema";
 import type { BrevDto } from "@schema/brevSchema.ts";
 import { mockData } from "mock/data";
 
+const dialogmoteBrevPath = "/api/v2/arbeidstaker/brev";
+const dialogmoteApiUrl = new URL(
+  dialogmoteBrevPath,
+  ISDIALOGMOTE_BACKEND_HOST,
+).toString();
+
 const realFetchBrev = async (token: string): Promise<BrevDto[]> => {
   return fetchFromBackend({
     token,
     clientId: ISDIALOGMOTE_CLIENT_ID,
-    apiUrl: ISDIALOGMOTE_API_URL,
+    apiUrl: dialogmoteApiUrl,
     apiName: "dialogmote",
     schema: brevSchema.array(),
   });

--- a/microfrontends/dialogmote/vitest.setup.ts
+++ b/microfrontends/dialogmote/vitest.setup.ts
@@ -9,6 +9,6 @@ vi.mock("@navikt/pino-logger", () => ({
 }));
 
 vi.mock("astro:env/server", () => ({
-  ISDIALOGMOTE_API_URL: "http://localhost:3000/api/dialogmote",
+  ISDIALOGMOTE_BACKEND_HOST: "http://localhost:3000",
   ISDIALOGMOTE_CLIENT_ID: "local:teamsykefravr:isdialogmote",
 }));

--- a/microfrontends/meroppfolging/astro.config.mjs
+++ b/microfrontends/meroppfolging/astro.config.mjs
@@ -39,10 +39,10 @@ export default defineConfig({
   }),
   env: {
     schema: {
-      MEROPPFOLGING_API_URL: envField.string({
+      MEROPPFOLGING_BACKEND_HOST: envField.string({
         context: "server",
         access: "secret",
-        default: "http://localhost:3000/api/mikrofrontend/v1/status",
+        default: "http://localhost:3000",
       }),
       MEROPPFOLGING_CLIENT_ID: envField.string({
         context: "server",

--- a/microfrontends/meroppfolging/nais/dev-gcp/nais.yaml
+++ b/microfrontends/meroppfolging/nais/dev-gcp/nais.yaml
@@ -39,8 +39,8 @@ spec:
       cpu: "20m"
       memory: 128Mi
   env:
-    - name: MEROPPFOLGING_API_URL
-      value: "http://meroppfolging-backend.team-esyfo/api/mikrofrontend/v1/status"
+    - name: MEROPPFOLGING_BACKEND_HOST
+      value: "http://meroppfolging-backend"
     - name: MEROPPFOLGING_CLIENT_ID
       value: "dev-gcp:team-esyfo:meroppfolging-backend"
     - name: SSPS_URL

--- a/microfrontends/meroppfolging/nais/dev-gcp/nais.yaml
+++ b/microfrontends/meroppfolging/nais/dev-gcp/nais.yaml
@@ -31,7 +31,6 @@ spec:
     outbound:
       rules:
         - application: meroppfolging-backend
-          namespace: team-esyfo
   resources:
     limits:
       memory: 768Mi

--- a/microfrontends/meroppfolging/nais/prod-gcp/nais.yaml
+++ b/microfrontends/meroppfolging/nais/prod-gcp/nais.yaml
@@ -39,8 +39,8 @@ spec:
       cpu: "20m"
       memory: 128Mi
   env:
-    - name: MEROPPFOLGING_API_URL
-      value: "http://meroppfolging-backend.team-esyfo/api/mikrofrontend/v1/status"
+    - name: MEROPPFOLGING_BACKEND_HOST
+      value: "http://meroppfolging-backend"
     - name: MEROPPFOLGING_CLIENT_ID
       value: "prod-gcp:team-esyfo:meroppfolging-backend"
     - name: SSPS_URL

--- a/microfrontends/meroppfolging/nais/prod-gcp/nais.yaml
+++ b/microfrontends/meroppfolging/nais/prod-gcp/nais.yaml
@@ -31,7 +31,6 @@ spec:
     outbound:
       rules:
         - application: meroppfolging-backend
-          namespace: team-esyfo
   resources:
     limits:
       memory: 768Mi

--- a/microfrontends/meroppfolging/src/infrastructure/fetch.ts
+++ b/microfrontends/meroppfolging/src/infrastructure/fetch.ts
@@ -1,5 +1,5 @@
 import {
-  MEROPPFOLGING_API_URL,
+  MEROPPFOLGING_BACKEND_HOST,
   MEROPPFOLGING_CLIENT_ID,
 } from "astro:env/server";
 import { isLocal } from "@esyfo/shared/environment";
@@ -10,13 +10,19 @@ import {
 } from "@schema/meroppfolgingStatusSchema";
 import { mockData } from "mock/data";
 
+const meroppfolgingStatusPath = "/api/mikrofrontend/v1/status";
+const meroppfolgingApiUrl = new URL(
+  meroppfolgingStatusPath,
+  MEROPPFOLGING_BACKEND_HOST,
+).toString();
+
 const realFetchStatus = async (
   token: string,
 ): Promise<MeroppfolgingStatusDto> => {
   return fetchFromBackend({
     token,
     clientId: MEROPPFOLGING_CLIENT_ID,
-    apiUrl: MEROPPFOLGING_API_URL,
+    apiUrl: meroppfolgingApiUrl,
     apiName: "meroppfolging",
     schema: meroppfolgingStatusSchema,
   });

--- a/microfrontends/meroppfolging/src/infrastructure/fetch.ts
+++ b/microfrontends/meroppfolging/src/infrastructure/fetch.ts
@@ -10,9 +10,8 @@ import {
 } from "@schema/meroppfolgingStatusSchema";
 import { mockData } from "mock/data";
 
-const meroppfolgingStatusPath = "/api/mikrofrontend/v1/status";
 const meroppfolgingApiUrl = new URL(
-  meroppfolgingStatusPath,
+  "/api/mikrofrontend/v1/status",
   MEROPPFOLGING_BACKEND_HOST,
 ).toString();
 

--- a/microfrontends/meroppfolging/vitest.setup.ts
+++ b/microfrontends/meroppfolging/vitest.setup.ts
@@ -9,7 +9,7 @@ vi.mock("@navikt/pino-logger", () => ({
 }));
 
 vi.mock("astro:env/server", () => ({
-  MEROPPFOLGING_API_URL: "http://localhost:3000/api/mikrofrontend/v1/status",
+  MEROPPFOLGING_BACKEND_HOST: "http://localhost:3000",
   MEROPPFOLGING_CLIENT_ID: "local:team-esyfo:meroppfolging-backend",
   SSPS_URL: "https://www.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene",
   KARTLEGGING_URL: "https://www.nav.no/syk/kartleggingssporsmal",

--- a/microfrontends/motebehov/astro.config.mjs
+++ b/microfrontends/motebehov/astro.config.mjs
@@ -39,10 +39,10 @@ export default defineConfig({
   }),
   env: {
     schema: {
-      SYFOMOTEBEHOV_API_URL: envField.string({
+      SYFOMOTEBEHOV_BACKEND_HOST: envField.string({
         context: "server",
         access: "secret",
-        default: "http://localhost:3000/api/motebehov",
+        default: "http://localhost:3000",
       }),
       SYFOMOTEBEHOV_CLIENT_ID: envField.string({
         context: "server",

--- a/microfrontends/motebehov/nais/dev-gcp/nais.yaml
+++ b/microfrontends/motebehov/nais/dev-gcp/nais.yaml
@@ -39,8 +39,8 @@ spec:
       cpu: "20m"
       memory: 128Mi
   env:
-    - name: SYFOMOTEBEHOV_API_URL
-      value: "http://syfomotebehov.team-esyfo/syfomotebehov/api/v4/arbeidstaker/motebehov"
+    - name: SYFOMOTEBEHOV_BACKEND_HOST
+      value: "http://syfomotebehov"
     - name: SYFOMOTEBEHOV_CLIENT_ID
       value: dev-gcp:team-esyfo:syfomotebehov
     - name: MOTEBEHOV_URL

--- a/microfrontends/motebehov/nais/dev-gcp/nais.yaml
+++ b/microfrontends/motebehov/nais/dev-gcp/nais.yaml
@@ -31,7 +31,6 @@ spec:
     outbound:
       rules:
         - application: syfomotebehov
-          namespace: team-esyfo
   resources:
     limits:
       memory: 768Mi

--- a/microfrontends/motebehov/nais/prod-gcp/nais.yaml
+++ b/microfrontends/motebehov/nais/prod-gcp/nais.yaml
@@ -39,8 +39,8 @@ spec:
       cpu: "20m"
       memory: 128Mi
   env:
-    - name: SYFOMOTEBEHOV_API_URL
-      value: "http://syfomotebehov.team-esyfo/syfomotebehov/api/v4/arbeidstaker/motebehov"
+    - name: SYFOMOTEBEHOV_BACKEND_HOST
+      value: "http://syfomotebehov"
     - name: SYFOMOTEBEHOV_CLIENT_ID
       value: prod-gcp:team-esyfo:syfomotebehov
     - name: MOTEBEHOV_URL

--- a/microfrontends/motebehov/nais/prod-gcp/nais.yaml
+++ b/microfrontends/motebehov/nais/prod-gcp/nais.yaml
@@ -31,7 +31,6 @@ spec:
     outbound:
       rules:
         - application: syfomotebehov
-          namespace: team-esyfo
   resources:
     limits:
       memory: 768Mi

--- a/microfrontends/motebehov/src/infrastructure/fetch.ts
+++ b/microfrontends/motebehov/src/infrastructure/fetch.ts
@@ -1,5 +1,5 @@
 import {
-  SYFOMOTEBEHOV_API_URL,
+  SYFOMOTEBEHOV_BACKEND_HOST,
   SYFOMOTEBEHOV_CLIENT_ID,
 } from "astro:env/server";
 import { isLocal } from "@esyfo/shared/environment";
@@ -10,13 +10,19 @@ import {
 } from "@schema/motebehovSchema.ts";
 import { mockData } from "mock/data";
 
+const motebehovPath = "/syfomotebehov/api/v4/arbeidstaker/motebehov";
+const motebehovApiUrl = new URL(
+  motebehovPath,
+  SYFOMOTEBEHOV_BACKEND_HOST,
+).toString();
+
 const realFetchMotebehov = async (
   token: string,
 ): Promise<MotebehovStatusDto> => {
   return fetchFromBackend({
     token,
     clientId: SYFOMOTEBEHOV_CLIENT_ID,
-    apiUrl: SYFOMOTEBEHOV_API_URL,
+    apiUrl: motebehovApiUrl,
     apiName: "motebehov",
     schema: motebehovStatusSchema,
   });

--- a/microfrontends/motebehov/src/infrastructure/fetch.ts
+++ b/microfrontends/motebehov/src/infrastructure/fetch.ts
@@ -10,9 +10,8 @@ import {
 } from "@schema/motebehovSchema.ts";
 import { mockData } from "mock/data";
 
-const motebehovPath = "/syfomotebehov/api/v4/arbeidstaker/motebehov";
 const motebehovApiUrl = new URL(
-  motebehovPath,
+  "/syfomotebehov/api/v4/arbeidstaker/motebehov",
   SYFOMOTEBEHOV_BACKEND_HOST,
 ).toString();
 

--- a/microfrontends/motebehov/vitest.setup.ts
+++ b/microfrontends/motebehov/vitest.setup.ts
@@ -9,6 +9,6 @@ vi.mock("@navikt/pino-logger", () => ({
 }));
 
 vi.mock("astro:env/server", () => ({
-  SYFOMOTEBEHOV_API_URL: "http://localhost:3000/api/motebehov",
+  SYFOMOTEBEHOV_BACKEND_HOST: "http://localhost:3000",
   SYFOMOTEBEHOV_CLIENT_ID: "local:team-esyfo:syfomotebehov",
 }));


### PR DESCRIPTION
## Beskrivelse

Rydder opp i backend-konfigurasjonen for de fire microfrontendene ved å skille service discovery-host fra API-path, og standardiserer URL-bygging i fetch-laget.

## Endringer

- `microfrontends/*/nais/*/nais.yaml`: erstatter `*_API_URL` med `*_BACKEND_HOST` og retter aktivitetskrav sitt prod-manifest
- `microfrontends/*/astro.config.mjs`: oppdaterer env-schema til host-baserte variabler
- `microfrontends/*/vitest.setup.ts`: oppdaterer testoppsett til `*_BACKEND_HOST`
- `microfrontends/*/src/infrastructure/fetch.ts`: flytter API-path inn i kode og standardiserer `new URL(path, host).toString()`

## Issue

Closes #111

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
