### PR TITLE
feat(github-actions): add hovmester sync workflow

### DIFF
--- a/.github/workflows/hovedmester-sync.yml
+++ b/.github/workflows/hovedmester-sync.yml
@@ -1,0 +1,15 @@
+name: Sync hovmester
+on:
+    schedule:
+        - cron: "0 5 * * *"
+    workflow_dispatch:
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    sync:
+        uses: navikt/hovmester/.github/workflows/hovmester-sync.yml@main
+        with:
+            collections: "frontend" # eller "backend", "backend,frontend"


### PR DESCRIPTION
## Beskrivelse

Legger til en GitHub Actions-workflow som kjører hovmester-sync for frontend-kolleksjonen manuelt og daglig.

## Endringer

- `.github/workflows/hovedmester-sync.yml`: oppretter ny workflow med `schedule` og `workflow_dispatch`
- `.github/workflows/hovedmester-sync.yml`: gjenbruker `navikt/hovmester/.github/workflows/hovmester-sync.yml@main` med `collections: "frontend"`

## Issue

Ingen issue. Dette setter opp automatisk synk av hovmester for frontend.

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [ ] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
