### PR TITLE
fix(readme): remove manifest id note

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ flowchart LR
 
 - [Lokal utvikling](docs/local-development.md)
 - [GitHub workflows](docs/github-workflows.md)
-- [Aktivering og deaktivering i esyfovarsel](docs/microfrontend-activation.md) – inkluderer manifest-id-er
+- [Aktivering og deaktivering i esyfovarsel](docs/microfrontend-activation.md)
 - [Integrasjon i Min side](docs/min-side-integration.md)
 - [Aktivitetskravarkitektur](docs/aktivitetskravarkitektur.md)
 - [Dialogmøtearkitektur](docs/dialogmotearkitektur.md)


### PR DESCRIPTION
## Beskrivelse

Fjerner unodvendig forklaringstekst i README-lenken til dokumentasjonen for aktivering og deaktivering i esyfovarsel.

## Endringer

- `README.md`: fjernet teksten `– inkluderer manifest-id-er` fra lenken til `docs/microfrontend-activation.md`

## Issue

Ingen koblet issue.

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [ ] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
