### PR TITLE
fix(deploy): update dev manifest urls

### DIFF
--- a/.github/workflows/deploy-aktivitetskrav.yaml
+++ b/.github/workflows/deploy-aktivitetskrav.yaml
@@ -28,7 +28,7 @@ jobs:
       cdn_source: "./microfrontends/aktivitetskrav/dist/client/_astro"
       manifest_id: "syfo-aktivitetskrav"
       application_name: "aktivitetskrav-microfrontend"
-      dev_manifest_url: "http://aktivitetskrav-microfrontend.min-side"
+      dev_manifest_url: "http://aktivitetskrav-microfrontend.team-esyfo"
       dev_resource: "microfrontends/aktivitetskrav/nais/dev-gcp/nais.yaml"
       enable_prod: false
     secrets: inherit

--- a/.github/workflows/deploy-dialogmote.yaml
+++ b/.github/workflows/deploy-dialogmote.yaml
@@ -28,7 +28,7 @@ jobs:
       cdn_source: "./microfrontends/dialogmote/dist/client/_astro"
       manifest_id: "syfo-dialog"
       application_name: "dialogmote-microfrontend"
-      dev_manifest_url: "http://dialogmote-microfrontend.min-side"
+      dev_manifest_url: "http://dialogmote-microfrontend.team-esyfo"
       dev_resource: "microfrontends/dialogmote/nais/dev-gcp/nais.yaml"
       enable_prod: false
     secrets: inherit

--- a/.github/workflows/deploy-meroppfolging.yaml
+++ b/.github/workflows/deploy-meroppfolging.yaml
@@ -28,7 +28,7 @@ jobs:
       cdn_source: "./microfrontends/meroppfolging/dist/client/_astro"
       manifest_id: "syfo-meroppfolging"
       application_name: "meroppfolging-microfrontend"
-      dev_manifest_url: "http://meroppfolging-microfrontend.min-side"
+      dev_manifest_url: "http://meroppfolging-microfrontend.team-esyfo"
       dev_resource: "microfrontends/meroppfolging/nais/dev-gcp/nais.yaml"
       enable_prod: false
     secrets: inherit


### PR DESCRIPTION
## Beskrivelse

Oppdaterer `dev_manifest_url` for mikrofrontendene slik at dev-manifestene peker til `team-esyfo`-domenet i stedet for `min-side`.

## Endringer

- `.github/workflows/deploy-dialogmote.yaml`: oppdaterer `dev_manifest_url`
- `.github/workflows/deploy-aktivitetskrav.yaml`: oppdaterer `dev_manifest_url`
- `.github/workflows/deploy-meroppfolging.yaml`: oppdaterer `dev_manifest_url`

## Issue

Ingen koblet issue.

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [ ] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
