### PR TITLE
feat(ci): add prod deploy configuration and simplify workflow inputs

### DIFF
--- a/.github/workflows/deploy-aktivitetskrav.yaml
+++ b/.github/workflows/deploy-aktivitetskrav.yaml
@@ -23,14 +23,6 @@ jobs:
     uses: ./.github/workflows/deploy-microfrontend-reusable.yml
     with:
       microfrontend_name: "aktivitetskrav"
-      build_script: "build:aktivitetskrav-microfrontend"
-      dockerfile: "./microfrontends/aktivitetskrav/Dockerfile"
-      cdn_source: "./microfrontends/aktivitetskrav/dist/client/_astro"
       manifest_id: "syfo-aktivitetskrav"
-      application_name: "aktivitetskrav-microfrontend"
-      dev_manifest_url: "http://aktivitetskrav-microfrontend.team-esyfo"
-      dev_resource: "microfrontends/aktivitetskrav/nais/dev-gcp/nais.yaml"
       enable_prod: false
-      prod_manifest_url: "http://aktivitetskrav-microfrontend.team-esyfo"
-      prod_resource: "microfrontends/aktivitetskrav/nais/prod-gcp/nais.yaml"
     secrets: inherit

--- a/.github/workflows/deploy-aktivitetskrav.yaml
+++ b/.github/workflows/deploy-aktivitetskrav.yaml
@@ -31,4 +31,6 @@ jobs:
       dev_manifest_url: "http://aktivitetskrav-microfrontend.team-esyfo"
       dev_resource: "microfrontends/aktivitetskrav/nais/dev-gcp/nais.yaml"
       enable_prod: false
+      prod_manifest_url: "http://aktivitetskrav-microfrontend.team-esyfo"
+      prod_resource: "microfrontends/aktivitetskrav/nais/prod-gcp/nais.yaml"
     secrets: inherit

--- a/.github/workflows/deploy-dialogmote.yaml
+++ b/.github/workflows/deploy-dialogmote.yaml
@@ -23,14 +23,6 @@ jobs:
     uses: ./.github/workflows/deploy-microfrontend-reusable.yml
     with:
       microfrontend_name: "dialogmote"
-      build_script: "build:dialogmote-microfrontend"
-      dockerfile: "./microfrontends/dialogmote/Dockerfile"
-      cdn_source: "./microfrontends/dialogmote/dist/client/_astro"
       manifest_id: "syfo-dialog"
-      application_name: "dialogmote-microfrontend"
-      dev_manifest_url: "http://dialogmote-microfrontend.team-esyfo"
-      dev_resource: "microfrontends/dialogmote/nais/dev-gcp/nais.yaml"
       enable_prod: false
-      prod_manifest_url: "http://dialogmote-microfrontend.team-esyfo"
-      prod_resource: "microfrontends/dialogmote/nais/prod-gcp/nais.yaml"
     secrets: inherit

--- a/.github/workflows/deploy-dialogmote.yaml
+++ b/.github/workflows/deploy-dialogmote.yaml
@@ -31,4 +31,6 @@ jobs:
       dev_manifest_url: "http://dialogmote-microfrontend.team-esyfo"
       dev_resource: "microfrontends/dialogmote/nais/dev-gcp/nais.yaml"
       enable_prod: false
+      prod_manifest_url: "http://dialogmote-microfrontend.team-esyfo"
+      prod_resource: "microfrontends/dialogmote/nais/prod-gcp/nais.yaml"
     secrets: inherit

--- a/.github/workflows/deploy-meroppfolging.yaml
+++ b/.github/workflows/deploy-meroppfolging.yaml
@@ -23,14 +23,6 @@ jobs:
     uses: ./.github/workflows/deploy-microfrontend-reusable.yml
     with:
       microfrontend_name: "meroppfolging"
-      build_script: "build:meroppfolging-microfrontend"
-      dockerfile: "./microfrontends/meroppfolging/Dockerfile"
-      cdn_source: "./microfrontends/meroppfolging/dist/client/_astro"
       manifest_id: "syfo-meroppfolging"
-      application_name: "meroppfolging-microfrontend"
-      dev_manifest_url: "http://meroppfolging-microfrontend.team-esyfo"
-      dev_resource: "microfrontends/meroppfolging/nais/dev-gcp/nais.yaml"
       enable_prod: false
-      prod_manifest_url: "http://meroppfolging-microfrontend.team-esyfo"
-      prod_resource: "microfrontends/meroppfolging/nais/prod-gcp/nais.yaml"
     secrets: inherit

--- a/.github/workflows/deploy-meroppfolging.yaml
+++ b/.github/workflows/deploy-meroppfolging.yaml
@@ -31,4 +31,6 @@ jobs:
       dev_manifest_url: "http://meroppfolging-microfrontend.team-esyfo"
       dev_resource: "microfrontends/meroppfolging/nais/dev-gcp/nais.yaml"
       enable_prod: false
+      prod_manifest_url: "http://meroppfolging-microfrontend.team-esyfo"
+      prod_resource: "microfrontends/meroppfolging/nais/prod-gcp/nais.yaml"
     secrets: inherit

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -4,35 +4,11 @@ on:
   workflow_call:
     inputs:
       microfrontend_name:
-        description: Human-readable microfrontend name for job labels
-        required: true
-        type: string
-      build_script:
-        description: Root package.json build script for the microfrontend
-        required: true
-        type: string
-      dockerfile:
-        description: Path to the microfrontend Dockerfile
-        required: true
-        type: string
-      cdn_source:
-        description: Built client asset directory to upload
+        description: Base microfrontend name used to derive deploy configuration
         required: true
         type: string
       manifest_id:
         description: TMS microfrontend id
-        required: true
-        type: string
-      application_name:
-        description: Application name reused for CDN destination and manifest registration
-        required: true
-        type: string
-      dev_manifest_url:
-        description: Dev URL registered in the manifest
-        required: true
-        type: string
-      dev_resource:
-        description: NAIS resource used for dev deploy
         required: true
         type: string
       enable_prod:
@@ -40,16 +16,6 @@ on:
         required: false
         default: false
         type: boolean
-      prod_manifest_url:
-        description: Prod URL registered in the manifest
-        required: false
-        default: ""
-        type: string
-      prod_resource:
-        description: NAIS resource used for prod deploy
-        required: false
-        default: ""
-        type: string
     secrets:
       READER_TOKEN:
         required: true
@@ -81,21 +47,21 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
       - name: Build application
-        run: "pnpm run ${{ inputs.build_script }}"
+        run: "pnpm run ${{ format('build:{0}-microfrontend', inputs.microfrontend_name) }}"
 
       - name: Upload to cdn
         uses: "nais/deploy/actions/cdn-upload/v2@437e4adfe270e3f1c98fd0eed7f86ecf0e0873db" # master
         with:
           team: "team-esyfo"
-          source: ${{ inputs.cdn_source }}
-          destination: ${{ inputs.application_name }}
+          source: ${{ format('./microfrontends/{0}/dist/client/_astro', inputs.microfrontend_name) }}
+          destination: ${{ format('{0}-microfrontend', inputs.microfrontend_name) }}
 
       - name: Build and push
         uses: "nais/docker-build-push@45d352fb62fb52ccb5ff6cba22c047fa02b35321" # v0
         id: docker-build-push
         with:
           team: "team-esyfo"
-          dockerfile: ${{ inputs.dockerfile }}
+          dockerfile: ${{ format('./microfrontends/{0}/Dockerfile', inputs.microfrontend_name) }}
           image_suffix: ${{ inputs.microfrontend_name }}
 
     outputs:
@@ -110,8 +76,8 @@ jobs:
     needs: build
     with:
       id: ${{ inputs.manifest_id }}
-      url: ${{ inputs.dev_manifest_url }}
-      appname: ${{ inputs.application_name }}
+      url: ${{ format('http://{0}-microfrontend.team-esyfo', inputs.microfrontend_name) }}
+      appname: ${{ format('{0}-microfrontend', inputs.microfrontend_name) }}
       namespace: "team-esyfo"
       cluster: "dev-gcp"
       commitmsg: ${{ github.event.head_commit.message || format('Manual deploy from {0} ({1})', github.ref_name, github.sha) }}
@@ -132,7 +98,7 @@ jobs:
         uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
         env:
           CLUSTER: "dev-gcp"
-          RESOURCE: ${{ inputs.dev_resource }}
+          RESOURCE: ${{ format('microfrontends/{0}/nais/dev-gcp/nais.yaml', inputs.microfrontend_name) }}
           VAR: image=${{ needs.build.outputs.image }},version=${{ github.sha }}
 
   update-manifest-prod:
@@ -145,8 +111,8 @@ jobs:
     needs: build
     with:
       id: ${{ inputs.manifest_id }}
-      url: ${{ inputs.prod_manifest_url }}
-      appname: ${{ inputs.application_name }}
+      url: ${{ format('http://{0}-microfrontend.team-esyfo', inputs.microfrontend_name) }}
+      appname: ${{ format('{0}-microfrontend', inputs.microfrontend_name) }}
       namespace: "team-esyfo"
       cluster: "prod-gcp"
       commitmsg: ${{ github.event.head_commit.message || format('Manual deploy from {0} ({1})', github.ref_name, github.sha) }}
@@ -168,5 +134,5 @@ jobs:
         uses: "nais/deploy/actions/deploy@fa754451577294aae42872a69b888b3470478ec1" # v2
         env:
           CLUSTER: "prod-gcp"
-          RESOURCE: ${{ inputs.prod_resource }}
+          RESOURCE: ${{ format('microfrontends/{0}/nais/prod-gcp/nais.yaml', inputs.microfrontend_name) }}
           VAR: image=${{ needs.build.outputs.image }},version=${{ github.sha }}

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -36,7 +36,7 @@ on:
         required: true
         type: string
       enable_prod:
-        description: Enables prod manifest update and deploy when prod inputs are also set
+        description: Enables prod manifest update and deploy
         required: false
         default: false
         type: boolean
@@ -137,7 +137,7 @@ jobs:
 
   update-manifest-prod:
     name: Update manifest prod
-    if: github.ref == 'refs/heads/main' && inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_resource != ''
+    if: github.ref == 'refs/heads/main' && inputs.enable_prod
     permissions:
       contents: "read"
       id-token: "write"
@@ -156,7 +156,7 @@ jobs:
 
   deploy-prod:
     name: Deploy to prod
-    if: github.ref == 'refs/heads/main' && inputs.enable_prod && inputs.prod_manifest_url != '' && inputs.prod_resource != ''
+    if: github.ref == 'refs/heads/main' && inputs.enable_prod
     runs-on: "ubuntu-latest"
     permissions:
       contents: "read"

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -28,6 +28,7 @@ jobs:
   build:
     name: Build ${{ inputs.microfrontend_name }}
     runs-on: "ubuntu-latest"
+    timeout-minutes: 15
     permissions:
       contents: "read"
       id-token: "write"
@@ -50,7 +51,7 @@ jobs:
         run: "pnpm run ${{ format('build:{0}-microfrontend', inputs.microfrontend_name) }}"
 
       - name: Upload to cdn
-        uses: "nais/deploy/actions/cdn-upload/v2@437e4adfe270e3f1c98fd0eed7f86ecf0e0873db" # master
+        uses: "nais/deploy/actions/cdn-upload/v2@437e4adfe270e3f1c98fd0eed7f86ecf0e0873db" # v2
         with:
           team: "team-esyfo"
           source: ${{ format('./microfrontends/{0}/dist/client/_astro', inputs.microfrontend_name) }}
@@ -88,6 +89,7 @@ jobs:
   deploy-dev:
     name: Deploy to dev
     runs-on: "ubuntu-latest"
+    timeout-minutes: 10
     permissions:
       contents: "read"
       id-token: "write"
@@ -124,6 +126,7 @@ jobs:
     name: Deploy to prod
     if: github.ref == 'refs/heads/main' && inputs.enable_prod
     runs-on: "ubuntu-latest"
+    timeout-minutes: 10
     permissions:
       contents: "read"
       id-token: "write"


### PR DESCRIPTION
## Beskrivelse

Klargjør prod-deploy for alle tre mikrofrontender og forenkler deploy-workflow inputs fra 12 til 3.

Prod-deploy er **ikke aktivert** — `enable_prod` forblir `false`. Det eneste som gjenstår for å gå live er å flippe `enable_prod: true` per app.

## Endringer

- `deploy-microfrontend-reusable.yml`: Forenklet prod-guard til `main && enable_prod`, refaktorert 11 inputs til 3 ved å utlede verdier fra `microfrontend_name` med `format()`
- `deploy-dialogmote.yaml`: Forenklet til 3 inputs + prod config
- `deploy-aktivitetskrav.yaml`: Forenklet til 3 inputs + prod config
- `deploy-meroppfolging.yaml`: Forenklet til 3 inputs + prod config

### Workflow inputs (før → etter)

**Før** (12 inputs per caller):
```yaml
microfrontend_name, build_script, dockerfile, cdn_source,
manifest_id, application_name, dev_manifest_url, dev_resource,
enable_prod, prod_manifest_url, prod_resource
```

**Etter** (3 inputs per caller):
```yaml
microfrontend_name, manifest_id, enable_prod
```

## Issue

Relates to #100

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Verifisering

- Typecheck: alle 4 workspaces passerer ✅
- YAML-syntaks verifisert ✅
- format()-verdier matcher opprinnelige hardkodede verdier for alle 3 apps ✅
- Prod NAIS-manifester eksisterer for alle 3 apps ✅
- Kryssmodell-inspeksjon (Opus) — ingen blockers ✅