### PR TITLE
fix(storybook): use correct Norwegian titles in story sidebar

### DIFF
--- a/microfrontends/dialogmote/src/stories/Dialogmote.stories.tsx
+++ b/microfrontends/dialogmote/src/stories/Dialogmote.stories.tsx
@@ -5,7 +5,7 @@ import { resolvePanel } from "../domain/panelResolver";
 import { createBrev } from "../domain/test-utils/brev";
 
 const meta = {
-  title: "Dialogmote",
+  title: "Dialogmøte",
   component: MainPanel,
 } satisfies Meta<typeof MainPanel>;
 

--- a/microfrontends/dialogmote/src/stories/Motebehov.stories.tsx
+++ b/microfrontends/dialogmote/src/stories/Motebehov.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { resolveMotebehovPanel } from "../domain/motebehovPanelResolver";
 
 const meta = {
-  title: "Dialogmote/Motebehov",
+  title: "Møtebehov",
   component: MainPanel,
 } satisfies Meta<typeof MainPanel>;
 

--- a/microfrontends/meroppfolging/src/stories/Meroppfolging.stories.tsx
+++ b/microfrontends/meroppfolging/src/stories/Meroppfolging.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from "../domain/test-utils/meroppfolgingStatus";
 
 const meta = {
-  title: "Meroppfolging",
+  title: "Meroppfølging",
   component: MainPanel,
 } satisfies Meta<typeof MainPanel>;
 


### PR DESCRIPTION
## Beskrivelse

Oppdaterer Storybook-titler til korrekt norsk og fjerner unødvendig gruppering som ga ulike ikoner i sidepanelet.

## Endringer

- `Dialogmote` → `Dialogmøte`
- `Dialogmote/Motebehov` → `Møtebehov` (flatet ut — fjerner folder-gruppering)
- `Meroppfolging` → `Meroppfølging`

Alle stories vises nå med samme ikon (📦) i sidepanelet.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Ingen sensitiv data eksponert