### PR TITLE
chore(storybook): hide addons panel, toolbar and set brand title

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,0 +1,14 @@
+import { addons } from "storybook/manager-api";
+import { create } from "storybook/theming";
+
+addons.setConfig({
+  theme: create({
+    base: "dark",
+    brandTitle: "eSyfo Microfrontends",
+    brandUrl: "https://github.com/navikt/esyfo-microfrontends",
+  }),
+  layoutCustomisations: {
+    showPanel: () => false,
+    showToolbar: () => false,
+  },
+});


### PR DESCRIPTION
## Beskrivelse

Tilpasser Storybook UI for en renere opplevelse:
- Skjuler addons-panelet (controls, actions, interactions) som standard
- Skjuler toolbar som standard
- Setter brand title til «esyfo-microfrontends»

Paneler kan fortsatt vises med tastatursnarvei (`A` for panel, `T` for toolbar).

## Endringer

- `.storybook/manager.ts`: Ny fil — konfigurerer Storybook manager med `layoutCustomisations` og custom theme

## Issue

Relates to #132

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)