### PR TITLE
ci(deploy): enable prod deployment for all microfrontends

### DIFF
--- a/.github/workflows/deploy-aktivitetskrav.yaml
+++ b/.github/workflows/deploy-aktivitetskrav.yaml
@@ -24,5 +24,5 @@ jobs:
     with:
       microfrontend_name: "aktivitetskrav"
       manifest_id: "syfo-aktivitetskrav"
-      enable_prod: false
+      enable_prod: true
     secrets: inherit

--- a/.github/workflows/deploy-dialogmote.yaml
+++ b/.github/workflows/deploy-dialogmote.yaml
@@ -24,5 +24,5 @@ jobs:
     with:
       microfrontend_name: "dialogmote"
       manifest_id: "syfo-dialog"
-      enable_prod: false
+      enable_prod: true
     secrets: inherit

--- a/.github/workflows/deploy-meroppfolging.yaml
+++ b/.github/workflows/deploy-meroppfolging.yaml
@@ -24,5 +24,5 @@ jobs:
     with:
       microfrontend_name: "meroppfolging"
       manifest_id: "syfo-meroppfolging"
-      enable_prod: false
+      enable_prod: true
     secrets: inherit

--- a/microfrontends/dialogmote/nais/dev-gcp/nais.yaml
+++ b/microfrontends/dialogmote/nais/dev-gcp/nais.yaml
@@ -1,10 +1,10 @@
 apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
-  name: dialogmote-microfrontend # Change this to your application name
-  namespace: team-esyfo # Change this to your namespace
+  name: dialogmote-microfrontend
+  namespace: team-esyfo
   labels:
-    team: team-esyfo # Change this to your team name
+    team: team-esyfo
 spec:
   observability:
     autoInstrumentation:
@@ -39,7 +39,7 @@ spec:
     requests:
       cpu: "20m"
       memory: 128Mi
-  env: # Add your environment variables here
+  env:
     - name: ISDIALOGMOTE_BACKEND_HOST
       value: "http://isdialogmote.teamsykefravr"
     - name: ISDIALOGMOTE_CLIENT_ID

--- a/microfrontends/dialogmote/nais/prod-gcp/nais.yaml
+++ b/microfrontends/dialogmote/nais/prod-gcp/nais.yaml
@@ -1,10 +1,10 @@
 apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
-  name: dialogmote-microfrontend # Change this to your application name
-  namespace: team-esyfo # Change this to your namespace
+  name: dialogmote-microfrontend
+  namespace: team-esyfo
   labels:
-    team: team-esyfo # Change this to your team name
+    team: team-esyfo
 spec:
   observability:
     autoInstrumentation:
@@ -39,7 +39,7 @@ spec:
     requests:
       cpu: "20m"
       memory: 128Mi
-  env: # Add your environment variables here
+  env:
     - name: ISDIALOGMOTE_BACKEND_HOST
       value: "http://isdialogmote.teamsykefravr"
     - name: ISDIALOGMOTE_CLIENT_ID


### PR DESCRIPTION
## Beskrivelse

Aktiverer produksjonsdeploy for alle tre mikrofrontender. Fjerner også template-kommentarer fra dialogmote NAIS-manifester.

## Endringer

- `deploy-dialogmote.yaml`: `enable_prod: false` → `true`
- `deploy-aktivitetskrav.yaml`: `enable_prod: false` → `true`
- `deploy-meroppfolging.yaml`: `enable_prod: false` → `true`
- `dialogmote/nais/dev-gcp/nais.yaml`: Fjernet template-kommentarer
- `dialogmote/nais/prod-gcp/nais.yaml`: Fjernet template-kommentarer

## Issue

Closes #100

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)