### PR TITLE
feat(observability): add structured render logging for all microfrontends

### DIFF
--- a/microfrontends/aktivitetskrav/src/pages/[locale]/fallback.astro
+++ b/microfrontends/aktivitetskrav/src/pages/[locale]/fallback.astro
@@ -1,6 +1,9 @@
 ---
 import { isLocal } from "@esyfo/shared/environment";
 import { Heading } from "@navikt/ds-react";
+import { logger } from "@navikt/pino-logger";
+
+logger.warn({ microfrontend: "aktivitetskrav" }, "fallback-rendered");
 ---
 
 {isLocal && <meta charset="UTF-8" />}

--- a/microfrontends/aktivitetskrav/src/pages/[locale]/index.astro
+++ b/microfrontends/aktivitetskrav/src/pages/[locale]/index.astro
@@ -2,6 +2,7 @@
 import { AKTIVITETSKRAV_URL } from "astro:env/server";
 import { MainPanel } from "@esyfo/shared/components";
 import { isLocal } from "@esyfo/shared/environment";
+import { logger } from "@navikt/pino-logger";
 import type { AktivitetskravVurdering } from "@schema/vurderingSchema";
 import { resolvePanel } from "@src/domain/panelResolver";
 import { fetchVurdering } from "@src/infrastructure/fetch";
@@ -16,6 +17,8 @@ try {
 }
 
 const panelProps = resolvePanel(vurdering, AKTIVITETSKRAV_URL, new Date());
+
+logger.info({ microfrontend: "aktivitetskrav" }, "microfrontend-rendered");
 ---
 
  {isLocal && <meta charset="UTF-8" />}

--- a/microfrontends/dialogmote/src/pages/[locale]/fallback.astro
+++ b/microfrontends/dialogmote/src/pages/[locale]/fallback.astro
@@ -1,6 +1,9 @@
 ---
 import { isLocal } from "@esyfo/shared/environment";
 import { Heading } from "@navikt/ds-react";
+import { logger } from "@navikt/pino-logger";
+
+logger.warn({ microfrontend: "dialogmote" }, "fallback-rendered");
 ---
 
 {isLocal && <meta charset="UTF-8" />}

--- a/microfrontends/dialogmote/src/pages/[locale]/index.astro
+++ b/microfrontends/dialogmote/src/pages/[locale]/index.astro
@@ -2,6 +2,7 @@
 import { DIALOGMOTE_URL } from "astro:env/server";
 import { MainPanel } from "@esyfo/shared/components";
 import { isLocal } from "@esyfo/shared/environment";
+import { logger } from "@navikt/pino-logger";
 import type { BrevDto } from "@schema/brevSchema";
 import type { MotebehovStatusDto } from "@schema/motebehovSchema";
 import { getLatestBrev } from "@src/domain/brev";
@@ -24,6 +25,8 @@ try {
 
 const latestBrev = getLatestBrev(brev);
 const panel = resolveCombinedPanel(latestBrev, motebehov, DIALOGMOTE_URL);
+
+logger.info({ microfrontend: "dialogmote" }, "microfrontend-rendered");
 ---
 
 {isLocal && <meta charset="UTF-8" />}

--- a/microfrontends/meroppfolging/src/pages/[locale]/fallback.astro
+++ b/microfrontends/meroppfolging/src/pages/[locale]/fallback.astro
@@ -1,6 +1,9 @@
 ---
 import { isLocal } from "@esyfo/shared/environment";
 import { Heading } from "@navikt/ds-react";
+import { logger } from "@navikt/pino-logger";
+
+logger.warn({ microfrontend: "meroppfolging" }, "fallback-rendered");
 ---
 
 {isLocal && <meta charset="UTF-8" />}

--- a/microfrontends/meroppfolging/src/pages/[locale]/index.astro
+++ b/microfrontends/meroppfolging/src/pages/[locale]/index.astro
@@ -2,6 +2,7 @@
 import { KARTLEGGING_URL, SSPS_URL } from "astro:env/server";
 import { MainPanel } from "@esyfo/shared/components";
 import { isLocal } from "@esyfo/shared/environment";
+import { logger } from "@navikt/pino-logger";
 import type { MeroppfolgingStatusDto } from "@schema/meroppfolgingStatusSchema";
 import { resolvePanel } from "@src/domain/panelResolver";
 import { fetchStatus } from "@src/infrastructure/fetch";
@@ -16,6 +17,8 @@ try {
 }
 
 const panelProps = resolvePanel(status, SSPS_URL, KARTLEGGING_URL, new Date());
+
+logger.info({ microfrontend: "meroppfolging" }, "microfrontend-rendered");
 ---
 
 {isLocal && <meta charset="UTF-8" />}


### PR DESCRIPTION
## Hva er endret?

Legger til strukturerte pino-loglinjer i alle tre mikrofrontends for å spore rendering i Loki/Grafana.

### Endringer

- `logger.info({ microfrontend: "<name>" }, "microfrontend-rendered")` i alle `index.astro`-sider (happy path)
- `logger.warn({ microfrontend: "<name>" }, "fallback-rendered")` i alle `fallback.astro`-sider (degradert tilstand)

### Loki-spørringer

Render-telling:
```
sum by (app) (count_over_time({namespace="team-esyfo"} |= "microfrontend-rendered" [$__auto]))
```

Fallback-alert:
```
count_over_time({namespace="team-esyfo"} |= "fallback-rendered" [$__auto]) > 0
```

### Filer endret

- `microfrontends/dialogmote/src/pages/[locale]/index.astro`
- `microfrontends/dialogmote/src/pages/[locale]/fallback.astro`
- `microfrontends/aktivitetskrav/src/pages/[locale]/index.astro`
- `microfrontends/aktivitetskrav/src/pages/[locale]/fallback.astro`
- `microfrontends/meroppfolging/src/pages/[locale]/index.astro`
- `microfrontends/meroppfolging/src/pages/[locale]/fallback.astro`

### Verifisert

- ✅ Alle 3 workspaces bygger OK
- ✅ Alle typechecks passerer
- ✅ Biome lint OK
