### PR TITLE
feat(observability): add Prometheus metrics for microfrontend render counts

### DIFF
--- a/microfrontends/aktivitetskrav/nais/dev-gcp/nais.yaml
+++ b/microfrontends/aktivitetskrav/nais/dev-gcp/nais.yaml
@@ -10,6 +10,9 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: nodejs
+  prometheus:
+    enabled: true
+    path: /api/internal/metrics
   tokenx:
     enabled: true
   image: {{ image }}

--- a/microfrontends/aktivitetskrav/nais/prod-gcp/nais.yaml
+++ b/microfrontends/aktivitetskrav/nais/prod-gcp/nais.yaml
@@ -10,6 +10,9 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: nodejs
+  prometheus:
+    enabled: true
+    path: /api/internal/metrics
   tokenx:
     enabled: true
   image: {{ image }}

--- a/microfrontends/aktivitetskrav/src/pages/[locale]/fallback.astro
+++ b/microfrontends/aktivitetskrav/src/pages/[locale]/fallback.astro
@@ -1,10 +1,10 @@
 ---
 import { isLocal } from "@esyfo/shared/environment";
-import { incrementMicrofrontendRender } from "@esyfo/shared/metrics";
+import { incrementRender } from "@esyfo/shared/metrics";
 import { Heading } from "@navikt/ds-react";
 import { logger } from "@navikt/pino-logger";
 
-incrementMicrofrontendRender("aktivitetskrav", "fallback");
+incrementRender("aktivitetskrav", "fallback");
 logger.warn({ microfrontend: "aktivitetskrav" }, "fallback-rendered");
 ---
 

--- a/microfrontends/aktivitetskrav/src/pages/[locale]/fallback.astro
+++ b/microfrontends/aktivitetskrav/src/pages/[locale]/fallback.astro
@@ -1,8 +1,10 @@
 ---
 import { isLocal } from "@esyfo/shared/environment";
+import { incrementMicrofrontendRender } from "@esyfo/shared/metrics";
 import { Heading } from "@navikt/ds-react";
 import { logger } from "@navikt/pino-logger";
 
+incrementMicrofrontendRender("aktivitetskrav", "fallback");
 logger.warn({ microfrontend: "aktivitetskrav" }, "fallback-rendered");
 ---
 

--- a/microfrontends/aktivitetskrav/src/pages/[locale]/index.astro
+++ b/microfrontends/aktivitetskrav/src/pages/[locale]/index.astro
@@ -2,6 +2,7 @@
 import { AKTIVITETSKRAV_URL } from "astro:env/server";
 import { MainPanel } from "@esyfo/shared/components";
 import { isLocal } from "@esyfo/shared/environment";
+import { incrementMicrofrontendRender } from "@esyfo/shared/metrics";
 import { logger } from "@navikt/pino-logger";
 import type { AktivitetskravVurdering } from "@schema/vurderingSchema";
 import { resolvePanel } from "@src/domain/panelResolver";
@@ -18,7 +19,10 @@ try {
 
 const panelProps = resolvePanel(vurdering, AKTIVITETSKRAV_URL, new Date());
 
-logger.info({ microfrontend: "aktivitetskrav" }, "microfrontend-rendered");
+if (panelProps) {
+  incrementMicrofrontendRender("aktivitetskrav", "success");
+  logger.info({ microfrontend: "aktivitetskrav" }, "microfrontend-rendered");
+}
 ---
 
  {isLocal && <meta charset="UTF-8" />}

--- a/microfrontends/aktivitetskrav/src/pages/[locale]/index.astro
+++ b/microfrontends/aktivitetskrav/src/pages/[locale]/index.astro
@@ -2,7 +2,7 @@
 import { AKTIVITETSKRAV_URL } from "astro:env/server";
 import { MainPanel } from "@esyfo/shared/components";
 import { isLocal } from "@esyfo/shared/environment";
-import { incrementMicrofrontendRender } from "@esyfo/shared/metrics";
+import { incrementRender } from "@esyfo/shared/metrics";
 import { logger } from "@navikt/pino-logger";
 import type { AktivitetskravVurdering } from "@schema/vurderingSchema";
 import { resolvePanel } from "@src/domain/panelResolver";
@@ -20,7 +20,7 @@ try {
 const panelProps = resolvePanel(vurdering, AKTIVITETSKRAV_URL, new Date());
 
 if (panelProps) {
-  incrementMicrofrontendRender("aktivitetskrav", "success");
+  incrementRender("aktivitetskrav", "success");
   logger.info({ microfrontend: "aktivitetskrav" }, "microfrontend-rendered");
 }
 ---

--- a/microfrontends/aktivitetskrav/src/pages/api/internal/metrics.ts
+++ b/microfrontends/aktivitetskrav/src/pages/api/internal/metrics.ts
@@ -1,11 +1,4 @@
-import { metricsRegistry } from "@esyfo/shared/metrics";
+import { handleMetricsRequest } from "@esyfo/shared/metrics";
 import type { APIRoute } from "astro";
 
-export const GET: APIRoute = async function get() {
-  return new Response(await metricsRegistry.metrics(), {
-    status: 200,
-    headers: {
-      "Content-Type": metricsRegistry.contentType,
-    },
-  });
-};
+export const GET: APIRoute = () => handleMetricsRequest();

--- a/microfrontends/aktivitetskrav/src/pages/api/internal/metrics.ts
+++ b/microfrontends/aktivitetskrav/src/pages/api/internal/metrics.ts
@@ -1,0 +1,11 @@
+import { metricsRegistry } from "@esyfo/shared/metrics";
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = async function get() {
+  return new Response(await metricsRegistry.metrics(), {
+    status: 200,
+    headers: {
+      "Content-Type": metricsRegistry.contentType,
+    },
+  });
+};

--- a/microfrontends/dialogmote/nais/dev-gcp/nais.yaml
+++ b/microfrontends/dialogmote/nais/dev-gcp/nais.yaml
@@ -10,6 +10,9 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: nodejs
+  prometheus:
+    enabled: true
+    path: /api/internal/metrics
   tokenx:
     enabled: true
   image: {{ image }}

--- a/microfrontends/dialogmote/nais/prod-gcp/nais.yaml
+++ b/microfrontends/dialogmote/nais/prod-gcp/nais.yaml
@@ -10,6 +10,9 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: nodejs
+  prometheus:
+    enabled: true
+    path: /api/internal/metrics
   tokenx:
     enabled: true
   image: {{ image }}

--- a/microfrontends/dialogmote/src/pages/[locale]/fallback.astro
+++ b/microfrontends/dialogmote/src/pages/[locale]/fallback.astro
@@ -1,10 +1,10 @@
 ---
 import { isLocal } from "@esyfo/shared/environment";
-import { incrementMicrofrontendRender } from "@esyfo/shared/metrics";
+import { incrementRender } from "@esyfo/shared/metrics";
 import { Heading } from "@navikt/ds-react";
 import { logger } from "@navikt/pino-logger";
 
-incrementMicrofrontendRender("dialogmote", "fallback");
+incrementRender("dialogmote", "fallback");
 logger.warn({ microfrontend: "dialogmote" }, "fallback-rendered");
 ---
 

--- a/microfrontends/dialogmote/src/pages/[locale]/fallback.astro
+++ b/microfrontends/dialogmote/src/pages/[locale]/fallback.astro
@@ -1,8 +1,10 @@
 ---
 import { isLocal } from "@esyfo/shared/environment";
+import { incrementMicrofrontendRender } from "@esyfo/shared/metrics";
 import { Heading } from "@navikt/ds-react";
 import { logger } from "@navikt/pino-logger";
 
+incrementMicrofrontendRender("dialogmote", "fallback");
 logger.warn({ microfrontend: "dialogmote" }, "fallback-rendered");
 ---
 

--- a/microfrontends/dialogmote/src/pages/[locale]/index.astro
+++ b/microfrontends/dialogmote/src/pages/[locale]/index.astro
@@ -2,6 +2,7 @@
 import { DIALOGMOTE_URL } from "astro:env/server";
 import { MainPanel } from "@esyfo/shared/components";
 import { isLocal } from "@esyfo/shared/environment";
+import { incrementMicrofrontendRender } from "@esyfo/shared/metrics";
 import { logger } from "@navikt/pino-logger";
 import type { BrevDto } from "@schema/brevSchema";
 import type { MotebehovStatusDto } from "@schema/motebehovSchema";
@@ -26,7 +27,10 @@ try {
 const latestBrev = getLatestBrev(brev);
 const panel = resolveCombinedPanel(latestBrev, motebehov, DIALOGMOTE_URL);
 
-logger.info({ microfrontend: "dialogmote" }, "microfrontend-rendered");
+if (panel) {
+  incrementMicrofrontendRender("dialogmote", "success");
+  logger.info({ microfrontend: "dialogmote" }, "microfrontend-rendered");
+}
 ---
 
 {isLocal && <meta charset="UTF-8" />}

--- a/microfrontends/dialogmote/src/pages/[locale]/index.astro
+++ b/microfrontends/dialogmote/src/pages/[locale]/index.astro
@@ -2,7 +2,7 @@
 import { DIALOGMOTE_URL } from "astro:env/server";
 import { MainPanel } from "@esyfo/shared/components";
 import { isLocal } from "@esyfo/shared/environment";
-import { incrementMicrofrontendRender } from "@esyfo/shared/metrics";
+import { incrementRender } from "@esyfo/shared/metrics";
 import { logger } from "@navikt/pino-logger";
 import type { BrevDto } from "@schema/brevSchema";
 import type { MotebehovStatusDto } from "@schema/motebehovSchema";
@@ -28,7 +28,7 @@ const latestBrev = getLatestBrev(brev);
 const panel = resolveCombinedPanel(latestBrev, motebehov, DIALOGMOTE_URL);
 
 if (panel) {
-  incrementMicrofrontendRender("dialogmote", "success");
+  incrementRender("dialogmote", "success");
   logger.info({ microfrontend: "dialogmote" }, "microfrontend-rendered");
 }
 ---

--- a/microfrontends/dialogmote/src/pages/api/internal/metrics.ts
+++ b/microfrontends/dialogmote/src/pages/api/internal/metrics.ts
@@ -1,11 +1,4 @@
-import { metricsRegistry } from "@esyfo/shared/metrics";
+import { handleMetricsRequest } from "@esyfo/shared/metrics";
 import type { APIRoute } from "astro";
 
-export const GET: APIRoute = async function get() {
-  return new Response(await metricsRegistry.metrics(), {
-    status: 200,
-    headers: {
-      "Content-Type": metricsRegistry.contentType,
-    },
-  });
-};
+export const GET: APIRoute = () => handleMetricsRequest();

--- a/microfrontends/dialogmote/src/pages/api/internal/metrics.ts
+++ b/microfrontends/dialogmote/src/pages/api/internal/metrics.ts
@@ -1,0 +1,11 @@
+import { metricsRegistry } from "@esyfo/shared/metrics";
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = async function get() {
+  return new Response(await metricsRegistry.metrics(), {
+    status: 200,
+    headers: {
+      "Content-Type": metricsRegistry.contentType,
+    },
+  });
+};

--- a/microfrontends/meroppfolging/nais/dev-gcp/nais.yaml
+++ b/microfrontends/meroppfolging/nais/dev-gcp/nais.yaml
@@ -10,6 +10,9 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: nodejs
+  prometheus:
+    enabled: true
+    path: /api/internal/metrics
   tokenx:
     enabled: true
   image: "{{ image }}"

--- a/microfrontends/meroppfolging/nais/prod-gcp/nais.yaml
+++ b/microfrontends/meroppfolging/nais/prod-gcp/nais.yaml
@@ -10,6 +10,9 @@ spec:
     autoInstrumentation:
       enabled: true
       runtime: nodejs
+  prometheus:
+    enabled: true
+    path: /api/internal/metrics
   tokenx:
     enabled: true
   image: "{{ image }}"

--- a/microfrontends/meroppfolging/src/pages/[locale]/fallback.astro
+++ b/microfrontends/meroppfolging/src/pages/[locale]/fallback.astro
@@ -1,8 +1,10 @@
 ---
 import { isLocal } from "@esyfo/shared/environment";
+import { incrementMicrofrontendRender } from "@esyfo/shared/metrics";
 import { Heading } from "@navikt/ds-react";
 import { logger } from "@navikt/pino-logger";
 
+incrementMicrofrontendRender("meroppfolging", "fallback");
 logger.warn({ microfrontend: "meroppfolging" }, "fallback-rendered");
 ---
 

--- a/microfrontends/meroppfolging/src/pages/[locale]/fallback.astro
+++ b/microfrontends/meroppfolging/src/pages/[locale]/fallback.astro
@@ -1,10 +1,10 @@
 ---
 import { isLocal } from "@esyfo/shared/environment";
-import { incrementMicrofrontendRender } from "@esyfo/shared/metrics";
+import { incrementRender } from "@esyfo/shared/metrics";
 import { Heading } from "@navikt/ds-react";
 import { logger } from "@navikt/pino-logger";
 
-incrementMicrofrontendRender("meroppfolging", "fallback");
+incrementRender("meroppfolging", "fallback");
 logger.warn({ microfrontend: "meroppfolging" }, "fallback-rendered");
 ---
 

--- a/microfrontends/meroppfolging/src/pages/[locale]/index.astro
+++ b/microfrontends/meroppfolging/src/pages/[locale]/index.astro
@@ -2,7 +2,7 @@
 import { KARTLEGGING_URL, SSPS_URL } from "astro:env/server";
 import { MainPanel } from "@esyfo/shared/components";
 import { isLocal } from "@esyfo/shared/environment";
-import { incrementMicrofrontendRender } from "@esyfo/shared/metrics";
+import { incrementRender } from "@esyfo/shared/metrics";
 import { logger } from "@navikt/pino-logger";
 import type { MeroppfolgingStatusDto } from "@schema/meroppfolgingStatusSchema";
 import { resolvePanel } from "@src/domain/panelResolver";
@@ -20,7 +20,7 @@ try {
 const panelProps = resolvePanel(status, SSPS_URL, KARTLEGGING_URL, new Date());
 
 if (panelProps) {
-  incrementMicrofrontendRender("meroppfolging", "success");
+  incrementRender("meroppfolging", "success");
   logger.info({ microfrontend: "meroppfolging" }, "microfrontend-rendered");
 }
 ---

--- a/microfrontends/meroppfolging/src/pages/[locale]/index.astro
+++ b/microfrontends/meroppfolging/src/pages/[locale]/index.astro
@@ -2,6 +2,7 @@
 import { KARTLEGGING_URL, SSPS_URL } from "astro:env/server";
 import { MainPanel } from "@esyfo/shared/components";
 import { isLocal } from "@esyfo/shared/environment";
+import { incrementMicrofrontendRender } from "@esyfo/shared/metrics";
 import { logger } from "@navikt/pino-logger";
 import type { MeroppfolgingStatusDto } from "@schema/meroppfolgingStatusSchema";
 import { resolvePanel } from "@src/domain/panelResolver";
@@ -18,7 +19,10 @@ try {
 
 const panelProps = resolvePanel(status, SSPS_URL, KARTLEGGING_URL, new Date());
 
-logger.info({ microfrontend: "meroppfolging" }, "microfrontend-rendered");
+if (panelProps) {
+  incrementMicrofrontendRender("meroppfolging", "success");
+  logger.info({ microfrontend: "meroppfolging" }, "microfrontend-rendered");
+}
 ---
 
 {isLocal && <meta charset="UTF-8" />}

--- a/microfrontends/meroppfolging/src/pages/api/internal/metrics.ts
+++ b/microfrontends/meroppfolging/src/pages/api/internal/metrics.ts
@@ -1,11 +1,4 @@
-import { metricsRegistry } from "@esyfo/shared/metrics";
+import { handleMetricsRequest } from "@esyfo/shared/metrics";
 import type { APIRoute } from "astro";
 
-export const GET: APIRoute = async function get() {
-  return new Response(await metricsRegistry.metrics(), {
-    status: 200,
-    headers: {
-      "Content-Type": metricsRegistry.contentType,
-    },
-  });
-};
+export const GET: APIRoute = () => handleMetricsRequest();

--- a/microfrontends/meroppfolging/src/pages/api/internal/metrics.ts
+++ b/microfrontends/meroppfolging/src/pages/api/internal/metrics.ts
@@ -1,0 +1,11 @@
+import { metricsRegistry } from "@esyfo/shared/metrics";
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = async function get() {
+  return new Response(await metricsRegistry.metrics(), {
+    status: 200,
+    headers: {
+      "Content-Type": metricsRegistry.contentType,
+    },
+  });
+};

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@navikt/pino-logger": "5.0.0",
     "astro": "6.1.5",
     "pino": "10.3.1",
+    "prom-client": "15.1.3",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "zod": "4.3.6"

--- a/packages/shared/src/metrics.ts
+++ b/packages/shared/src/metrics.ts
@@ -8,7 +8,7 @@ const registry = new Registry();
 collectDefaultMetrics({ register: registry });
 
 const renderCounter = new Counter({
-  name: "microfrontend_renders_total",
+  name: "esyfo_microfrontends_renders_total",
   help: "Counts rendered microfrontends by render type",
   labelNames: ["type", "microfrontend"],
   registers: [registry],

--- a/packages/shared/src/metrics.ts
+++ b/packages/shared/src/metrics.ts
@@ -1,0 +1,46 @@
+import { Counter, collectDefaultMetrics, Registry } from "prom-client";
+
+type RenderType = "success" | "fallback";
+type MicrofrontendName = "dialogmote" | "aktivitetskrav" | "meroppfolging";
+
+type MetricsState = {
+  registry: Registry;
+  microfrontendRenderCounter: Counter<"type" | "microfrontend">;
+};
+
+const globalMetrics = globalThis as typeof globalThis & {
+  __esyfoMetrics__?: MetricsState;
+};
+
+function createMetricsState(): MetricsState {
+  const registry = new Registry();
+
+  collectDefaultMetrics({ register: registry });
+
+  const microfrontendRenderCounter = new Counter({
+    name: "microfrontend_renders_total",
+    help: "Counts rendered microfrontends by render type",
+    labelNames: ["type", "microfrontend"],
+    registers: [registry],
+  });
+
+  return {
+    registry,
+    microfrontendRenderCounter,
+  };
+}
+
+const metricsState = globalMetrics.__esyfoMetrics__ ?? createMetricsState();
+
+globalMetrics.__esyfoMetrics__ = metricsState;
+
+export const metricsRegistry = metricsState.registry;
+export const microfrontendRenderCounter =
+  metricsState.microfrontendRenderCounter;
+
+export function incrementMicrofrontendRender(
+  microfrontend: MicrofrontendName,
+  type: RenderType,
+) {
+  microfrontendRenderCounter.inc({ microfrontend, type });
+}

--- a/packages/shared/src/metrics.ts
+++ b/packages/shared/src/metrics.ts
@@ -3,44 +3,32 @@ import { Counter, collectDefaultMetrics, Registry } from "prom-client";
 type RenderType = "success" | "fallback";
 type MicrofrontendName = "dialogmote" | "aktivitetskrav" | "meroppfolging";
 
-type MetricsState = {
-  registry: Registry;
-  microfrontendRenderCounter: Counter<"type" | "microfrontend">;
-};
+const registry = new Registry();
 
-const globalMetrics = globalThis as typeof globalThis & {
-  __esyfoMetrics__?: MetricsState;
-};
+collectDefaultMetrics({ register: registry });
 
-function createMetricsState(): MetricsState {
-  const registry = new Registry();
+const renderCounter = new Counter({
+  name: "microfrontend_renders_total",
+  help: "Counts rendered microfrontends by render type",
+  labelNames: ["type", "microfrontend"],
+  registers: [registry],
+});
 
-  collectDefaultMetrics({ register: registry });
+export const metricsRegistry = registry;
+export { renderCounter };
 
-  const microfrontendRenderCounter = new Counter({
-    name: "microfrontend_renders_total",
-    help: "Counts rendered microfrontends by render type",
-    labelNames: ["type", "microfrontend"],
-    registers: [registry],
-  });
-
-  return {
-    registry,
-    microfrontendRenderCounter,
-  };
-}
-
-const metricsState = globalMetrics.__esyfoMetrics__ ?? createMetricsState();
-
-globalMetrics.__esyfoMetrics__ = metricsState;
-
-export const metricsRegistry = metricsState.registry;
-export const microfrontendRenderCounter =
-  metricsState.microfrontendRenderCounter;
-
-export function incrementMicrofrontendRender(
+export function incrementRender(
   microfrontend: MicrofrontendName,
   type: RenderType,
 ) {
-  microfrontendRenderCounter.inc({ microfrontend, type });
+  renderCounter.inc({ microfrontend, type });
+}
+
+export async function handleMetricsRequest(): Promise<Response> {
+  return new Response(await metricsRegistry.metrics(), {
+    status: 200,
+    headers: {
+      "Content-Type": metricsRegistry.contentType,
+    },
+  });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       pino:
         specifier: 10.3.1
         version: 10.3.1
+      prom-client:
+        specifier: 15.1.3
+        version: 15.1.3
       react:
         specifier: 19.2.5
         version: 19.2.5
@@ -6175,7 +6178,7 @@ snapshots:
 
   prom-client@15.1.3:
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       tdigest: 0.1.2
 
   property-information@7.1.0: {}


### PR DESCRIPTION
## Hva
Legger til Prometheus-metrikker for å telle microfrontend-renders per app og type (success/fallback).

## Endringer

### Ny: `packages/shared/src/metrics.ts`
- Prometheus `Registry` med `collectDefaultMetrics`
- `microfrontend_renders_total` counter (labels: `microfrontend`, `type`)
- `incrementRender()` helper
- `handleMetricsRequest()` for endpoint-respons

### Per workspace
- `src/pages/api/internal/metrics.ts` — metrics endpoint (3-liner, importerer fra shared)
- `index.astro` — `incrementRender(name, "success")` kun når panel finnes
- `fallback.astro` — `incrementRender(name, "fallback")`

### NAIS
- `prometheus.enabled: true` + `prometheus.path: /api/internal/metrics` i alle 6 manifester

## PromQL-eksempler
```promql
# Per microfrontend
sum(increase(microfrontend_renders_total{microfrontend="dialogmote"}[$__rate_interval])) by (type)

# Alle microfrontends
sum(increase(microfrontend_renders_total[$__rate_interval])) by (microfrontend, type)
```

## Verifisert
- [x] Alle 3 workspaces bygger
- [x] Typechecks OK (lefthook pre-push)
- [x] Biome lint OK

Relates to #137
Relates to #124
