### PR TITLE
refactor(logging): remove redundant success render logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Astro SSR-monorepo (server side rendering) for eSyfo-mikrofronter på Min side. 
 
 [🧩 TMS (Team Min Side)-dokumentasjon for microfrontends](https://navikt.github.io/tms-dokumentasjon/microfrontend/)
 
+[📊 Grafana — Funksjonelle metrikker](https://grafana.nav.cloud.nais.io/d/be6i7hziaaiv4f/funksjonelle-metrikker?orgId=1)
+
+[🚨 Grafana — Error summary](https://grafana.nav.cloud.nais.io/d/eeivq822edhj4c/esyfo3a-error-summary?orgId=1)
+
 ## Formålet med repoet
 
 Repoet samler eSyfo-mikrofronter som vises på Min side. Hver mikrofrontend er en Astro SSR-app som validerer token i middleware, henter data på serversiden og renderer et panel med felles komponenter fra `@esyfo/shared`.

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Astro SSR-monorepo (server side rendering) for eSyfo-mikrofronter på Min side. 
 
 [🎬 Storybook](https://navikt.github.io/esyfo-microfrontends/)
 
-[🧩 TMS (Team Min Side)-dokumentasjon for microfrontends](https://navikt.github.io/tms-dokumentasjon/microfrontend/)
+[🚨 Grafana — Error summary](https://grafana.nav.cloud.nais.io/d/eeivq822edhj4c/esyfo3a-error-summary?orgId=1)
 
 [📊 Grafana — Funksjonelle metrikker](https://grafana.nav.cloud.nais.io/d/be6i7hziaaiv4f/funksjonelle-metrikker?orgId=1)
 
-[🚨 Grafana — Error summary](https://grafana.nav.cloud.nais.io/d/eeivq822edhj4c/esyfo3a-error-summary?orgId=1)
+[🧩 TMS (Team Min Side)-dokumentasjon for microfrontends](https://navikt.github.io/tms-dokumentasjon/microfrontend/)
 
 ## Formålet med repoet
 

--- a/microfrontends/aktivitetskrav/src/pages/[locale]/index.astro
+++ b/microfrontends/aktivitetskrav/src/pages/[locale]/index.astro
@@ -3,7 +3,6 @@ import { AKTIVITETSKRAV_URL } from "astro:env/server";
 import { MainPanel } from "@esyfo/shared/components";
 import { isLocal } from "@esyfo/shared/environment";
 import { incrementRender } from "@esyfo/shared/metrics";
-import { logger } from "@navikt/pino-logger";
 import type { AktivitetskravVurdering } from "@schema/vurderingSchema";
 import { resolvePanel } from "@src/domain/panelResolver";
 import { fetchVurdering } from "@src/infrastructure/fetch";
@@ -21,7 +20,6 @@ const panelProps = resolvePanel(vurdering, AKTIVITETSKRAV_URL, new Date());
 
 if (panelProps) {
   incrementRender("aktivitetskrav", "success");
-  logger.info({ microfrontend: "aktivitetskrav" }, "microfrontend-rendered");
 }
 ---
 

--- a/microfrontends/dialogmote/src/pages/[locale]/index.astro
+++ b/microfrontends/dialogmote/src/pages/[locale]/index.astro
@@ -3,7 +3,6 @@ import { DIALOGMOTE_URL } from "astro:env/server";
 import { MainPanel } from "@esyfo/shared/components";
 import { isLocal } from "@esyfo/shared/environment";
 import { incrementRender } from "@esyfo/shared/metrics";
-import { logger } from "@navikt/pino-logger";
 import type { BrevDto } from "@schema/brevSchema";
 import type { MotebehovStatusDto } from "@schema/motebehovSchema";
 import { getLatestBrev } from "@src/domain/brev";
@@ -29,7 +28,6 @@ const panel = resolveCombinedPanel(latestBrev, motebehov, DIALOGMOTE_URL);
 
 if (panel) {
   incrementRender("dialogmote", "success");
-  logger.info({ microfrontend: "dialogmote" }, "microfrontend-rendered");
 }
 ---
 

--- a/microfrontends/meroppfolging/src/pages/[locale]/index.astro
+++ b/microfrontends/meroppfolging/src/pages/[locale]/index.astro
@@ -3,7 +3,6 @@ import { KARTLEGGING_URL, SSPS_URL } from "astro:env/server";
 import { MainPanel } from "@esyfo/shared/components";
 import { isLocal } from "@esyfo/shared/environment";
 import { incrementRender } from "@esyfo/shared/metrics";
-import { logger } from "@navikt/pino-logger";
 import type { MeroppfolgingStatusDto } from "@schema/meroppfolgingStatusSchema";
 import { resolvePanel } from "@src/domain/panelResolver";
 import { fetchStatus } from "@src/infrastructure/fetch";
@@ -21,7 +20,6 @@ const panelProps = resolvePanel(status, SSPS_URL, KARTLEGGING_URL, new Date());
 
 if (panelProps) {
   incrementRender("meroppfolging", "success");
-  logger.info({ microfrontend: "meroppfolging" }, "microfrontend-rendered");
 }
 ---
 


### PR DESCRIPTION
## Endringer

Fjerner `logger.info("microfrontend-rendered")` fra success-pathen i alle tre microfrontends. Prometheus-metrikker (`esyfo_microfrontends_renders_total`) dekker nå render-telling.

**Beholdt:** `logger.warn("fallback-rendered")` i fallback-sidene — nyttig for debugging i Loki.

### Filer endret
- `microfrontends/dialogmote/src/pages/[locale]/index.astro`
- `microfrontends/aktivitetskrav/src/pages/[locale]/index.astro`
- `microfrontends/meroppfolging/src/pages/[locale]/index.astro`

Relatert til #137