### PR TITLE
ci(deploy): remove enable_prod flag from workflows

### DIFF
--- a/.github/workflows/deploy-aktivitetskrav.yaml
+++ b/.github/workflows/deploy-aktivitetskrav.yaml
@@ -24,5 +24,4 @@ jobs:
     with:
       microfrontend_name: "aktivitetskrav"
       manifest_id: "syfo-aktivitetskrav"
-      enable_prod: true
     secrets: inherit

--- a/.github/workflows/deploy-dialogmote.yaml
+++ b/.github/workflows/deploy-dialogmote.yaml
@@ -24,5 +24,4 @@ jobs:
     with:
       microfrontend_name: "dialogmote"
       manifest_id: "syfo-dialog"
-      enable_prod: true
     secrets: inherit

--- a/.github/workflows/deploy-meroppfolging.yaml
+++ b/.github/workflows/deploy-meroppfolging.yaml
@@ -24,5 +24,4 @@ jobs:
     with:
       microfrontend_name: "meroppfolging"
       manifest_id: "syfo-meroppfolging"
-      enable_prod: true
     secrets: inherit

--- a/.github/workflows/deploy-microfrontend-reusable.yml
+++ b/.github/workflows/deploy-microfrontend-reusable.yml
@@ -11,11 +11,6 @@ on:
         description: TMS microfrontend id
         required: true
         type: string
-      enable_prod:
-        description: Enables prod manifest update and deploy
-        required: false
-        default: false
-        type: boolean
     secrets:
       READER_TOKEN:
         required: true
@@ -105,7 +100,7 @@ jobs:
 
   update-manifest-prod:
     name: Update manifest prod
-    if: github.ref == 'refs/heads/main' && inputs.enable_prod
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: "read"
       id-token: "write"
@@ -124,7 +119,7 @@ jobs:
 
   deploy-prod:
     name: Deploy to prod
-    if: github.ref == 'refs/heads/main' && inputs.enable_prod
+    if: github.ref == 'refs/heads/main'
     runs-on: "ubuntu-latest"
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Beskrivelse

Alle tre microfrontends er prodsatt. `enable_prod`-flagget er nå bare støy — fjerner det slik at prod-deploy trigges automatisk på push til main.

## Endringer

- `deploy-microfrontend-reusable.yml`: Fjernet `enable_prod`-input og forenklet `if`-betingelser til `github.ref == 'refs/heads/main'`
- `deploy-dialogmote.yaml`: Fjernet `enable_prod: true`
- `deploy-aktivitetskrav.yaml`: Fjernet `enable_prod: true`
- `deploy-meroppfolging.yaml`: Fjernet `enable_prod: true`

## Issue

Closes #127

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)