### PR TITLE
fix(dialogmote): add EKSPERTBISTAND to documentComponentKey schema

### DIFF
--- a/microfrontends/dialogmote/schema/brevSchema.ts
+++ b/microfrontends/dialogmote/schema/brevSchema.ts
@@ -48,6 +48,7 @@ const documentComponentKey = union([
   literal("UNNTAK_ARBEIDSGIVERPERIODE"),
   literal("REISETILSKUDD"),
   literal("HJELPEMIDLER_TILRETTELEGGING"),
+  literal("EKSPERTBISTAND"),
   literal("MIDLERTIDIG_LONNSTILSKUDD"),
   literal("OKONOMISK_STOTTE"),
   literal("INGEN_RETTIGHETER"),


### PR DESCRIPTION
## Beskrivelse

Backend sender `EKSPERTBISTAND` som gyldig `documentComponentKey`, men verdien manglet fra Zod-unionen i `brevSchema.ts`. Dette førte til at `safeParse` feilet med en warning-logg, og nøkkelen falt tilbake til `"UNKNOWN"`.

## Endringer

- `microfrontends/dialogmote/schema/brevSchema.ts`: Lagt til `literal("EKSPERTBISTAND")` i `documentComponentKey`-unionen

## Issue

Closes #142

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)