### PR TITLE
ci(workflows): skip storybook and main-ci on doc-only changes

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -3,6 +3,12 @@ name: Deploy Storybook to GitHub Pages
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".github/instructions/**"
+      - ".github/skills/**"
+      - "LICENSE"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".github/instructions/**"
+      - ".github/skills/**"
+      - "LICENSE"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Endringer

Legger til `paths-ignore` på `deploy-storybook.yml` og `main-ci.yaml` slik at dokumentasjonsendringer (markdown, docs/, instructions, skills, LICENSE) ikke trigger unødvendige CI-kjøringer og Storybook-deploys.

### Endrede filer
- `.github/workflows/deploy-storybook.yml` — paths-ignore for docs
- `.github/workflows/main-ci.yaml` — paths-ignore for docs

`workflow_dispatch` er fortsatt tilgjengelig for manuelle kjøringer.