### PR TITLE
fix: use all registries for Dependabot npm resolution

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,7 @@ registries:
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    registries:
-      - github-npm
+    registries: '*'
     schedule:
       interval: "weekly"
     cooldown:


### PR DESCRIPTION
## Hva

Endrer Dependabot registry-konfigurasjon fra en eksplisitt liste (`- github-npm`) til wildcard (`'*'`) slik at GitHub Packages brukes **i tillegg til** standard npmjs-registeret.

## Hvorfor

Dependabot feilet med:
> No matching version found for @types/react@19.2.14 while fetching it from https://npm.pkg.github.com/

Den eksplisitte listen erstattet default npmjs-registeret, og pakker som `@types/react` finnes ikke på GitHub Packages.

## Endring

- `.github/dependabot.yml`: `registries: - github-npm` → `registries: '*'`

Samme mønster som [narmesteleder-frontend](https://github.com/navikt/narmesteleder-frontend/blob/main/.github/dependabot.yml).

Closes #146