### PR TITLE
fix(dependabot): ignore pnpm action major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,10 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "pnpm/action-setup"
+        update-types:
+          - "version-update:semver-major"
     groups:
       actions:
         patterns:

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-exact=true


### PR DESCRIPTION
## Beskrivelse

Ignorer major-versjonsoppdateringer for `pnpm/action-setup` i Dependabot for github-actions, og fjern den unødvendige `.npmrc`-filen som kun satte `save-exact=true`.

## Endringer

- `.github/dependabot.yml`: la til ignore-regel for `pnpm/action-setup` major-bumps i `github-actions`-økosystemet
- `.npmrc`: slettet filen siden `save-exact=true` ikke trengs
- Lukket feilende Dependabot-PR #148 med forklarende kommentar

## Issue

Closes #149

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)