### PR TITLE
chore(repo): restore save-exact and document dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,8 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    # pnpm/action-setup v6 bundler pnpm 11 som er inkompatibelt med vår pnpm 10 lockfile.
+    # Fjern denne ignore-regelen når repoet migrerer til pnpm 11.
     ignore:
       - dependency-name: "pnpm/action-setup"
         update-types:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
## Hva

Oppfølging av PR #150 — utbedrer inspektør-funn:

1. **Gjenopprettet `.npmrc`** med `save-exact=true` — alle dependencies i `package.json` bruker eksakte versjoner, denne innstillingen enforcer mønsteret ved `pnpm add`.
2. **Lagt til kommentar** i `.github/dependabot.yml` som forklarer hvorfor `pnpm/action-setup` major bumps ignoreres.

## Hvorfor

Inspeksjon av PR #150 avdekket:
- 🟡 `save-exact=true` ble fjernet ved sletting av `.npmrc`, men eksakte versjoner var et bevisst mønster
- 🟡 Manglende kommentar på ignore-regelen gjør det uklart hvorfor den finnes

Relates to #149