### PR TITLE
fix(dependabot): add registry config to .npmrc for Dependabot resolution

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,4 @@
+//npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}
+@navikt:registry=https://npm.pkg.github.com
+registry=https://registry.npmjs.org/
 save-exact=true


### PR DESCRIPTION
## Hva

Legger til eksplisitt registry-routing i `.npmrc` slik at pnpm (og Dependabot) vet at:
- `@navikt/*` → GitHub Packages
- Alt annet → npmjs.org

## Hvorfor

Dependabot feiler fortsatt med:
> No matching version found for @types/node@25.6.0 while fetching it from https://npm.pkg.github.com/

`registries: '*'` i `dependabot.yml` (PR #147) var ikke nok alene — pnpm trenger også `.npmrc` med registry-scoping for å vite hvilke pakker som hører til hvilken registry.

Matcher konfigurasjonen fra [narmesteleder-frontend](https://github.com/navikt/narmesteleder-frontend/blob/main/.github/.npmrc).

Relates to #146