### PR TITLE
chore(mise): improve task naming

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -22,32 +22,32 @@ description = "Run lint and formatter checks"
 depends = ["install"]
 run = "pnpm run check:fix"
 
-[tasks.dev-dialogmote]
+[tasks."dialogmote:dev"]
 description = "Run dev server for dialogmote"
 depends = ["install"]
 run = "pnpm run dev:dialogmote-microfrontend"
 
-[tasks.dev-aktivitetskrav]
+[tasks."aktivitetskrav:dev"]
 description = "Run dev server for aktivitetskrav"
 depends = ["install"]
 run = "pnpm run dev:aktivitetskrav-microfrontend"
 
-[tasks.dev-meroppfolging]
+[tasks."meroppfolging:dev"]
 description = "Run dev server for meroppfolging"
 depends = ["install"]
 run = "pnpm run dev:meroppfolging-microfrontend"
 
-[tasks.build-dialogmote]
+[tasks."dialogmote:build"]
 description = "Create production build for dialogmote"
 depends = ["install"]
 run = "pnpm run build:dialogmote-microfrontend"
 
-[tasks.build-aktivitetskrav]
+[tasks."aktivitetskrav:build"]
 description = "Create production build for aktivitetskrav"
 depends = ["install"]
 run = "pnpm run build:aktivitetskrav-microfrontend"
 
-[tasks.build-meroppfolging]
+[tasks."meroppfolging:build"]
 description = "Create production build for meroppfolging"
 depends = ["install"]
 run = "pnpm run build:meroppfolging-microfrontend"
@@ -68,12 +68,12 @@ run = ["pnpm run check",
 "pnpm run build-storybook"
 ]
 
-[tasks.storybook]
+[tasks."storybook:dev"]
 description = "Run Storybook dev server"
 depends = ["install"]
 run = "pnpm run storybook"
 
-[tasks.build-storybook]
+[tasks."storybook:build"]
 description = "Build Storybook static site"
 depends = ["install"]
 run = "pnpm run build-storybook"


### PR DESCRIPTION
## Beskrivelse

Gjor task-navnene i `mise.toml` mer konsistente ved a bruke formatet `domene:kommando`. Det gjor kommandoene lettere a finne og gruppere i `mise`.

## Endringer

- `mise.toml`: Endret dev-oppgaver til `dialogmote:dev`, `aktivitetskrav:dev` og `meroppfolging:dev`
- `mise.toml`: Endret build-oppgaver til `dialogmote:build`, `aktivitetskrav:build` og `meroppfolging:build`
- `mise.toml`: Endret Storybook-oppgaver til `storybook:dev` og `storybook:build`

## Issue

Ingen lenket issue.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
