### PR TITLE
docs(readme): flytt emoji utenfor markdown-lenker

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 
 Astro SSR-monorepo (server side rendering) for eSyfo-mikrofronter på Min side. Inneholder [aktivitetskrav](docs/aktivitetskravarkitektur.md), [dialogmøte](docs/dialogmotearkitektur.md) og [meroppfølging](docs/meroppfolgingsarkitektur.md), med felles [bygg og deploy](docs/github-workflows.md) og [dokumentasjon](#les-mer).
 
-[🎬 Storybook](https://navikt.github.io/esyfo-microfrontends/)
+🎬 [Storybook](https://navikt.github.io/esyfo-microfrontends/)
 
-[🚨 Grafana — Error summary](https://grafana.nav.cloud.nais.io/d/eeivq822edhj4c/esyfo3a-error-summary?orgId=1)
+🚨 [Grafana — Error summary](https://grafana.nav.cloud.nais.io/d/eeivq822edhj4c/esyfo3a-error-summary?orgId=1)
 
-[📊 Grafana — Funksjonelle metrikker](https://grafana.nav.cloud.nais.io/d/be6i7hziaaiv4f/funksjonelle-metrikker?orgId=1)
+📊 [Grafana — Funksjonelle metrikker](https://grafana.nav.cloud.nais.io/d/be6i7hziaaiv4f/funksjonelle-metrikker?orgId=1)
 
-[🧩 TMS (Team Min Side)-dokumentasjon for microfrontends](https://navikt.github.io/tms-dokumentasjon/microfrontend/)
+🧩 [TMS (Team Min Side)-dokumentasjon for microfrontends](https://navikt.github.io/tms-dokumentasjon/microfrontend/)
 
 ## Formålet med repoet
 


### PR DESCRIPTION
## Beskrivelse

Flytter emoji-ikon foran markdown-lenkene i README i stedet for inni dem. Gir bedre visuell rendering — noen klienter viser emoji som del av lenketeksten med uheldig styling.

## Endringer

- `README.md`: Emoji plassert foran `[tekst](url)` i stedet for `[🎬 tekst](url)`

## Issue

Ingen issue — kosmetisk forbedring.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)